### PR TITLE
Poll whole region with configurable Netbox endpoint

### DIFF
--- a/charts/openstack-hypervisor-operator/templates/deployment.yaml
+++ b/charts/openstack-hypervisor-operator/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         command:
         - /manager
         env:
+        - name: NETBOX_GRAPHQL_URL
+          value: {{ quote .Values.controllerManager.manager.env.netboxGraphqlUrl }}
+        - name: CLUSTER_TYPE_ID
+          value: {{ quote .Values.controllerManager.manager.env.clusterTypeId }}
         - name: OS_AUTH_URL
           value: {{ quote .Values.controllerManager.manager.env.osAuthUrl }}
         - name: OS_PROJECT_DOMAIN_NAME

--- a/charts/openstack-hypervisor-operator/values.yaml
+++ b/charts/openstack-hypervisor-operator/values.yaml
@@ -4,12 +4,17 @@ controllerManager:
     - --metrics-bind-address=:8443
     - --leader-elect
     - --health-probe-bind-address=:8081
+    - --netbox-graphql-url=${NETBOX_GRAPHQL_URL}
+    - --region=${OS_REGION_NAME}
+    - --cluster-type-id=${CLUSTER_TYPE_ID}
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL
     env:
+      clusterTypeId: ""
+      netboxGraphqlUrl: ""
       osAuthUrl: ""
       osProjectDomainName: ""
       osProjectName: ""

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,7 +63,12 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
+          - --netbox-graphql-url=${NETBOX_GRAPHQL_URL}
+          - --region=${OS_REGION_NAME}
+          - --cluster-type-id=${CLUSTER_TYPE_ID}
         env:
+          - name: NETBOX_GRAPHQL_URL
+          - name: CLUSTER_TYPE_ID
           - name: OS_AUTH_URL
           - name: OS_PROJECT_DOMAIN_NAME
           - name: OS_PROJECT_NAME

--- a/internal/netbox/clusters.go
+++ b/internal/netbox/clusters.go
@@ -1,0 +1,111 @@
+/*
+SPDX-FileCopyrightText: Copyright 2024 SAP SE or an SAP affiliate company and cobaltcore-dev contributors
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netbox
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+type ipAddress struct {
+	Address string `json:"address"`
+}
+
+type ipsInterface struct {
+	MacAddress  string      `json:"mac_address"`
+	IPAddresses []ipAddress `json:"ip_addresses"`
+}
+
+type ipsDevice struct {
+	Name       string         `json:"name"`
+	Interfaces []ipsInterface `json:"interfaces"`
+}
+
+type clusterListItem struct {
+	Name    string      `json:"name"`
+	Devices []ipsDevice `json:"devices"`
+}
+
+type ipsData struct {
+	ClusterList []clusterListItem `json:"cluster_list"`
+}
+
+type ipsResponse struct {
+	Data ipsData `json:"data"`
+}
+
+const _QUERY_CLUSTER = `query pollClusters($region: [String!]!, $type_id: [String!]!) {
+	cluster_list(region: $region, type_id: $type_id) {
+		name devices {
+			name interfaces {
+				mac_address ip_addresses {
+					address
+				}
+			}
+		}
+	}
+}`
+
+// GetHostName retrieves the host name from Netbox by the given MAC address.
+func (n *netboxClient) pollClusters(ctx context.Context) error {
+	if n.nextPoll.After(time.Now()) {
+		return nil
+	}
+
+	vars := map[string]any{"region": n.region, "type_id": n.clusterTypeIDs}
+	response := &ipsResponse{}
+	if err := queryNetbox(ctx, n.graphQLURL, _QUERY_CLUSTER, vars, response); err != nil {
+		return err
+	}
+
+	if len(response.Data.ClusterList) == 0 {
+		return errors.New("could not find any matching clusters / hosts")
+	}
+
+	clusterNames := make([]string, 0)
+	ipsForHost := make(map[string][]string)
+	hostnameForMac := make(map[string]string)
+
+	for _, netboxCluster := range response.Data.ClusterList {
+		clusterNames = append(clusterNames, netboxCluster.Name)
+		for _, device := range netboxCluster.Devices {
+			ipList := make([]string, 0)
+			for _, intf := range device.Interfaces {
+				if intf.MacAddress != "" {
+					mac := strings.ToLower(intf.MacAddress)
+					hostnameForMac[mac] = device.Name
+				}
+
+				for _, addr := range intf.IPAddresses {
+					ip, _, _ := strings.Cut(addr.Address, "/")
+					ipList = append(ipList, ip)
+				}
+			}
+
+			ipsForHost[device.Name] = ipList
+		}
+	}
+
+	n.clusterNames = clusterNames
+	n.ipsForHost = ipsForHost
+	n.hostnameForMac = hostnameForMac
+	n.nextPoll = time.Now().Add(15 * time.Minute) // TODO: Make it configurable
+	return nil
+}

--- a/internal/netbox/common.go
+++ b/internal/netbox/common.go
@@ -1,0 +1,110 @@
+/*
+SPDX-FileCopyrightText: Copyright 2024 SAP SE or an SAP affiliate company and cobaltcore-dev contributors
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netbox
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type netboxQuery struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+type Client interface {
+	GetHostName(ctx context.Context, macAddress string) (string, error)
+	GetIpsForHost(ctx context.Context, hostname string) ([]string, error)
+	GetClusterNames(ctx context.Context) ([]string, error)
+}
+
+type netboxClient struct {
+	graphQLURL     string
+	nextPoll       time.Time
+	region         string
+	clusterTypeIDs []string
+	hostnameForMac map[string]string
+	ipsForHost     map[string][]string
+	clusterNames   []string
+}
+
+func NewClient(graphQLURL, region string, clusterTypeIDs []string) *netboxClient {
+	if !strings.HasSuffix(graphQLURL, "/") {
+		graphQLURL = graphQLURL + "/"
+	}
+	return &netboxClient{graphQLURL, time.Now(), region, clusterTypeIDs, nil, nil, nil}
+}
+
+func (n *netboxClient) GetIpsForHost(ctx context.Context, hostname string) ([]string, error) {
+	if err := n.pollClusters(ctx); err != nil {
+		return nil, err
+	}
+
+	ips, found := n.ipsForHost[hostname]
+	if !found {
+		return nil, fmt.Errorf("cannot find ips for host %q", hostname)
+	}
+
+	return ips, nil
+}
+
+func (n *netboxClient) GetClusterNames(ctx context.Context) ([]string, error) {
+	if err := n.pollClusters(ctx); err != nil {
+		return nil, err
+	}
+
+	return n.clusterNames, nil
+}
+
+func queryNetbox[ResponseType any](ctx context.Context, graphQLURL, query string, variables map[string]any, response *ResponseType) error {
+	payload := new(bytes.Buffer)
+	if err := json.NewEncoder(payload).Encode(netboxQuery{Query: query, Variables: variables}); err != nil {
+		return err
+	}
+
+	r, err := http.NewRequest("POST", graphQLURL, payload)
+	if err != nil {
+		return err
+	}
+	r.Header.Add("Accept", "application/graphql-response+json")
+	r.Header.Add("Content-Type", "application/json")
+
+	c := http.DefaultClient
+	res, err := c.Do(r.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("received unexpected status %v", res.Status)
+	}
+
+	defer func() { _ = res.Body.Close() }()
+
+	err = json.NewDecoder(res.Body).Decode(response)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Instead of querying the data on a host by host basis, we can pull the whole data in one go. The data is presumably slow changing, so we limit the polling to a (for now fixed) period.