### PR TITLE
Use explicily 64-bit for RAM and Disk sizes

### DIFF
--- a/api/v1/eviction_types.go
+++ b/api/v1/eviction_types.go
@@ -49,7 +49,7 @@ type EvictionStatus struct {
 	HypervisorServiceId string `json:"hypervisorServiceId"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=0
-	OutstandingRamMb int `json:"outstandingRamMb"`
+	OutstandingRamMb int64 `json:"outstandingRamMb"`
 	// +kubebuilder:validation:Optional
 	OutstandingInstances []string `json:"outstandingInstances"`
 

--- a/charts/openstack-hypervisor-operator/crds/eviction-crd.yaml
+++ b/charts/openstack-hypervisor-operator/crds/eviction-crd.yaml
@@ -142,6 +142,7 @@ spec:
                 type: array
               outstandingRamMb:
                 default: 0
+                format: int64
                 type: integer
             required:
             - evictionState

--- a/config/crd/bases/kvm.cloud.sap_evictions.yaml
+++ b/config/crd/bases/kvm.cloud.sap_evictions.yaml
@@ -143,6 +143,7 @@ spec:
                 type: array
               outstandingRamMb:
                 default: 0
+                format: int64
                 type: integer
             required:
             - evictionState

--- a/internal/openstack/hypervisor.go
+++ b/internal/openstack/hypervisor.go
@@ -34,17 +34,17 @@ type Hypervisor struct {
 	CPUInfo            string `json:"cpu_info"`
 	CurrentWorkload    int    `json:"current_workload"`
 	DiskAvailableLeast any    `json:"disk_available_least"`
-	FreeDiskGb         int    `json:"free_disk_gb"`
-	FreeRAMMb          int    `json:"free_ram_mb"`
+	FreeDiskGb         int64  `json:"free_disk_gb"`
+	FreeRAMMb          int64  `json:"free_ram_mb"`
 	HostIP             string `json:"host_ip"`
 	HypervisorHostname string `json:"hypervisor_hostname"`
 	HypervisorType     string `json:"hypervisor_type"`
 	HypervisorVersion  int    `json:"hypervisor_version"`
 	ID                 string `json:"id"`
-	LocalGb            int    `json:"local_gb"`
-	LocalGbUsed        int    `json:"local_gb_used"`
-	MemoryMb           int    `json:"memory_mb"`
-	MemoryMbUsed       int    `json:"memory_mb_used"`
+	LocalGb            int64  `json:"local_gb"`
+	LocalGbUsed        int64  `json:"local_gb_used"`
+	MemoryMb           int64  `json:"memory_mb"`
+	MemoryMbUsed       int64  `json:"memory_mb_used"`
 	RunningVms         int    `json:"running_vms"`
 	Service            struct {
 		DisabledReason any    `json:"disabled_reason"`


### PR DESCRIPTION
While we will only use 64-bit machines, and on these it will be 64-bit by default, it doesn't hurt to be explicit about it.