### PR TITLE
Drop enableHypervisorServiceInternal

### DIFF
--- a/internal/controller/eviction_controller.go
+++ b/internal/controller/eviction_controller.go
@@ -318,14 +318,10 @@ func (r *EvictionReconciler) enableHypervisorService(ctx context.Context, client
 		return nil
 	}
 
-	return r.enableHypervisorServiceInternal(ctx, hypervisor.Service.ID)
-}
-
-func (r *EvictionReconciler) enableHypervisorServiceInternal(ctx context.Context, id string) error {
 	log := logger.FromContext(ctx)
 	enableService := services.UpdateOpts{Status: services.ServiceEnabled}
-	log.Info("Enabling hypervisor", "id", id)
-	_, err := services.Update(ctx, r.serviceClient, id, enableService).Extract()
+	log.Info("Enabling hypervisor", "id", hypervisor.Service.ID)
+	_, err = services.Update(ctx, r.serviceClient, hypervisor.Service.ID, enableService).Extract()
 	return err
 }
 


### PR DESCRIPTION
It isn't called anywhere else anymore and is just three lines of code.