### PR TITLE
Rename the labels

### DIFF
--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Node Controller", func() {
 			resource := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   nodeName,
-					Labels: map[string]string{HOST_LABEL: "test", MAINTENANCE_REQUIRED_LABEL: "true"},
+					Labels: map[string]string{HOST_LABEL: "test", EVICTION_REQUIRED_LABEL: "true"},
 				},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())


### PR DESCRIPTION
The idea was that the labels are more specific, so another operator can choose the action instead of assuming a common convention.