### PR TITLE
filtering status-only changes in the eviction_controller

### DIFF
--- a/internal/controller/eviction_controller.go
+++ b/internal/controller/eviction_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kvmv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
@@ -478,5 +479,6 @@ func (r *EvictionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kvmv1.Eviction{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }


### PR DESCRIPTION
Because we do a Status().Update() in `evictNext` which immediately leads to a reconciliation because the status changed and (thesis) to a later reconciliation because of the exponential backoff of the returned error.

Therefore, here we filter out events that do not alter the kubernetes _generation_ which should catch Status-only updates.

See [Slack](https://convergedcloud.slack.com/archives/C06JTCKNMDM/p1751271413934059?thread_ts=1750150900.360169&cid=C06JTCKNMDM) discussion.