### PR TITLE
Switch Hypervisor from ControllerReference to OwnerReference

### DIFF
--- a/internal/controller/hypervisor_controller.go
+++ b/internal/controller/hypervisor_controller.go
@@ -153,7 +153,7 @@ func (hv *HypervisorController) Reconcile(ctx context.Context, req ctrl.Request)
 		})
 	}
 
-	if err := controllerutil.SetControllerReference(node, hypervisor, hv.Scheme); err != nil {
+	if err := controllerutil.SetOwnerReference(node, hypervisor, hv.Scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed setting controller reference: %w", err)
 	}
 
@@ -180,7 +180,6 @@ func (hv *HypervisorController) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Node{}).
-		Owns(&kvmv1.Hypervisor{}).
 		WithEventFilter(novaVirtLabeledPredicate).
 		Complete(hv)
 }


### PR DESCRIPTION
ControllerReference is 'for reconciling the owner object on changes to controlled (with a Watch + EnqueueRequestForOwner)'.

Since we do not want to reconcile the node on changes to the hypervisor, we are fine with OwnerReference.

The WithBlockOwnerDeletion ensures that the node is only deleted, when the hypervisor resource also has been deleted. For now, it is only avoiding a theoretical race conditition of the node coming back before the hypervisor has been removed, and annotations / labels not getting propagated.

It also sets the stage for moving the finalizer out of the node, and doing that on the hypervisor resource instead.