### PR TITLE
Onboarding: Undo forceDown

### DIFF
--- a/internal/controller/onboarding_controller.go
+++ b/internal/controller/onboarding_controller.go
@@ -199,8 +199,14 @@ func (r *OnboardingController) initialOnboarding(ctx context.Context, hv *kvmv1.
 		}
 	}
 
-	if result := services.Update(ctx, r.computeClient, hv.Status.ServiceID,
-		services.UpdateOpts{Status: services.ServiceEnabled}); result.Err != nil {
+	// The service may be forced down previously due to an HA event,
+	// so we need to ensure it not only enabled, but also not forced to be down.
+	falseVal := false
+	opts := openstack.UpdateServiceOpts{
+		Status:     services.ServiceEnabled,
+		ForcedDown: &falseVal,
+	}
+	if result := openstack.UpdateService(ctx, r.computeClient, hv.Status.ServiceID, opts); result.Err != nil {
 		return result.Err
 	}
 

--- a/internal/openstack/services.go
+++ b/internal/openstack/services.go
@@ -1,0 +1,67 @@
+/*
+SPDX-FileCopyrightText: Copyright 2024 SAP SE or an SAP affiliate company and cobaltcore-dev contributors
+SPDX-FileCopyrightText: Copyright Gophercloud authors
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Temporary workaround until gophercloud v3 has been released.
+ * Functions and structs copied from:
+ * https://github.com/gophercloud/gophercloud/tree/main/openstack/compute/v2/services
+ * and renamed to contain "Service".
+ */
+
+package openstack
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/services"
+)
+
+type UpdateServiceOpts struct {
+	// Status represents the new service status. One of enabled or disabled.
+	Status services.ServiceStatus `json:"status,omitempty"`
+
+	// DisabledReason represents the reason for disabling a service.
+	DisabledReason string `json:"disabled_reason,omitempty"`
+
+	// ForcedDown is a manual override to tell nova that the service in question
+	// has been fenced manually by the operations team.
+	ForcedDown *bool `json:"forced_down,omitempty"`
+}
+
+// ToServiceUpdateMap formats an UpdateServiceOpts structure into a request body.
+func (opts UpdateServiceOpts) ToServiceUpdateMap() (map[string]any, error) {
+	return gophercloud.BuildRequestBody(opts, "")
+}
+
+func updateServiceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("os-services", id)
+}
+
+// UpdateService requests that various attributes of the indicated service be changed.
+func UpdateService(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateServiceOpts) (r services.UpdateResult) {
+	b, err := opts.ToServiceUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(ctx, updateServiceURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}


### PR DESCRIPTION
An HA event on a node will cause the HA service to force down the node. 
This is apparently persisted, so when the node comes up again, it stays forced down, 
even though the service was deleted.

Either way, we can only onboard a node if it isn't forcedDown, so we might as well ensure that.

We need to duplicate the gophercloud code until v3 is released, as the bugfix is unfortunately a breaking api change. See: https://github.com/gophercloud/gophercloud/pull/3531

In compliance with the Apache License, I kept the attribution and wrote down where the code came from and what has been changed.