### PR TITLE
Update to gophercloud 2.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ module github.com/cobaltcore-dev/openstack-hypervisor-operator
 go 1.24.7
 
 require (
-	github.com/gophercloud/gophercloud/v2 v2.7.0
-	github.com/gophercloud/utils/v2 v2.0.0-20250711132455-9770683b100a
+	github.com/gophercloud/gophercloud/v2 v2.8.0
+	github.com/gophercloud/utils/v2 v2.0.0-20250930154317-576cdf6142a7
 	github.com/onsi/ginkgo/v2 v2.26.0
 	github.com/onsi/gomega v1.38.2
 	k8s.io/api v0.34.1

--- a/go.sum
+++ b/go.sum
@@ -75,10 +75,10 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gophercloud/gophercloud/v2 v2.7.0 h1:o0m4kgVcPgHlcXiWAjoVxGd8QCmvM5VU+YM71pFbn0E=
-github.com/gophercloud/gophercloud/v2 v2.7.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
-github.com/gophercloud/utils/v2 v2.0.0-20250711132455-9770683b100a h1:erVLycqmezd0+eukgQ4xgLxGsByDKvqJxLXVc35tUYI=
-github.com/gophercloud/utils/v2 v2.0.0-20250711132455-9770683b100a/go.mod h1:1mckc18GQSFLRhDy2BjPGkkpbrjxY5iwX/oxpdTE2kw=
+github.com/gophercloud/gophercloud/v2 v2.8.0 h1:of2+8tT6+FbEYHfYC8GBu8TXJNsXYSNm9KuvpX7Neqo=
+github.com/gophercloud/gophercloud/v2 v2.8.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
+github.com/gophercloud/utils/v2 v2.0.0-20250930154317-576cdf6142a7 h1:y0/17y47lq1dD97qEqbbvjsMF8PzLmqmD839aOePRuc=
+github.com/gophercloud/utils/v2 v2.0.0-20250930154317-576cdf6142a7/go.mod h1:dVCIqYUB0Q8JDbMZaReU6BkAQAS9j3l3Kyc7GuSIztU=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/controller/decomission_controller_test.go
+++ b/internal/controller/decomission_controller_test.go
@@ -20,7 +20,6 @@ package controller
 import (
 	"context"
 
-	"github.com/gophercloud/gophercloud/v2/testhelper"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -88,9 +87,6 @@ var _ = Describe("Decommission Controller", func() {
 
 		It("should successfully reconcile the resource", func(ctx context.Context) {
 			By("ConditionType the created resource")
-			testhelper.SetupHTTP()
-			defer testhelper.TeardownHTTP()
-
 			req := ctrl.Request{
 				NamespacedName: types.NamespacedName{Name: nodeName},
 			}

--- a/internal/controller/node_eviction_label_controller_test.go
+++ b/internal/controller/node_eviction_label_controller_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Node Eviction Label Controller", func() {
 	var (
 		nodeReconciler *NodeEvictionLabelReconciler
 		req            = ctrl.Request{NamespacedName: types.NamespacedName{Name: nodeName}}
+		fakeServer     testhelper.FakeServer
 	)
 
 	Context("When reconciling a node", func() {
@@ -61,8 +62,8 @@ var _ = Describe("Node Eviction Label Controller", func() {
 		}
 
 		BeforeEach(func() {
-			testhelper.SetupHTTP()
-			Expect(os.Setenv("KVM_HA_SERVICE_URL", testhelper.Endpoint())).To(Succeed())
+			fakeServer = testhelper.SetupHTTP()
+			Expect(os.Setenv("KVM_HA_SERVICE_URL", fakeServer.Endpoint())).To(Succeed())
 			nodeReconciler = &NodeEvictionLabelReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
@@ -120,7 +121,7 @@ var _ = Describe("Node Eviction Label Controller", func() {
 			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
 			By("Cleanup the specific node")
 			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, node))).To(Succeed())
-			testhelper.TeardownHTTP()
+			fakeServer.Teardown()
 		})
 
 		It("should successfully reconcile the resource", func() {

--- a/internal/controller/onboarding_controller.go
+++ b/internal/controller/onboarding_controller.go
@@ -206,7 +206,7 @@ func (r *OnboardingController) initialOnboarding(ctx context.Context, hv *kvmv1.
 		Status:     services.ServiceEnabled,
 		ForcedDown: &falseVal,
 	}
-	if result := openstack.UpdateService(ctx, r.computeClient, hv.Status.ServiceID, opts); result.Err != nil {
+	if result := services.Update(ctx, r.computeClient, hv.Status.ServiceID, opts); result.Err != nil {
 		return result.Err
 	}
 

--- a/internal/controller/onboarding_controller_test.go
+++ b/internal/controller/onboarding_controller_test.go
@@ -20,7 +20,6 @@ package controller
 import (
 	"context"
 
-	"github.com/gophercloud/gophercloud/v2/testhelper"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +31,9 @@ import (
 )
 
 var _ = Describe("Onboarding Controller", func() {
-	var onboardingReconciler *OnboardingController
+	var (
+		onboardingReconciler *OnboardingController
+	)
 
 	Context("When reconciling a hypervisor", func() {
 		const hypervisorName = "some-test"
@@ -66,15 +67,9 @@ var _ = Describe("Onboarding Controller", func() {
 				Spec: kvmv1.HypervisorSpec{},
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-			By("Setting up the OpenStack http mock server")
-			testhelper.SetupHTTP()
 		})
 
 		AfterEach(func() {
-			By("Clean up the OpenStack http mock server")
-			testhelper.TeardownHTTP()
-
 			hv := &kvmv1.Hypervisor{ObjectMeta: metav1.ObjectMeta{Name: hypervisorName}}
 			By("Cleanup the specific hypervisor CRO")
 			Expect(client.IgnoreAlreadyExists(k8sClient.Delete(ctx, hv))).To(Succeed())

--- a/internal/openstack/services.go
+++ b/internal/openstack/services.go
@@ -25,8 +25,6 @@ limitations under the License.
 package openstack
 
 import (
-	"context"
-
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/services"
 )
@@ -46,22 +44,4 @@ type UpdateServiceOpts struct {
 // ToServiceUpdateMap formats an UpdateServiceOpts structure into a request body.
 func (opts UpdateServiceOpts) ToServiceUpdateMap() (map[string]any, error) {
 	return gophercloud.BuildRequestBody(opts, "")
-}
-
-func updateServiceURL(c *gophercloud.ServiceClient, id string) string {
-	return c.ServiceURL("os-services", id)
-}
-
-// UpdateService requests that various attributes of the indicated service be changed.
-func UpdateService(ctx context.Context, client *gophercloud.ServiceClient, id string, opts UpdateServiceOpts) (r services.UpdateResult) {
-	b, err := opts.ToServiceUpdateMap()
-	if err != nil {
-		r.Err = err
-		return
-	}
-	resp, err := client.Put(ctx, updateServiceURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{200},
-	})
-	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
-	return
 }


### PR DESCRIPTION
testhelper returns now a fake-server that needs to be passed around. In turn, we can drop copied code for updating the service.