### PR TITLE
Name all controllers explicitly with constants

### DIFF
--- a/internal/controller/aggregates_controller.go
+++ b/internal/controller/aggregates_controller.go
@@ -40,6 +40,7 @@ const (
 	ConditionTypeAggregatesUpdated = "AggregatesUpdated"
 	ConditionAggregatesSuccess     = "Success"
 	ConditionAggregatesFailed      = "Failed"
+	AggregatesControllerName       = "aggregates"
 )
 
 type AggregatesController struct {
@@ -138,7 +139,7 @@ func (ac *AggregatesController) SetupWithManager(mgr ctrl.Manager) error {
 	ac.computeClient.Microversion = "2.40" // gophercloud only supports numeric ids
 
 	return ctrl.NewControllerManagedBy(mgr).
-		Named("aggregates").
+		Named(AggregatesControllerName).
 		For(&kvmv1.Hypervisor{}).
 		Complete(ac)
 }

--- a/internal/controller/decomission_controller.go
+++ b/internal/controller/decomission_controller.go
@@ -44,7 +44,8 @@ import (
 )
 
 const (
-	decommissionFinalizerName = "cobaltcore.cloud.sap/decommission-hypervisor"
+	decommissionFinalizerName  = "cobaltcore.cloud.sap/decommission-hypervisor"
+	DecommissionControllerName = "nodeDecommission"
 )
 
 type NodeDecommissionReconciler struct {
@@ -222,7 +223,7 @@ func (r *NodeDecommissionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	})
 
 	return ctrl.NewControllerManagedBy(mgr).
-		Named("nodeDecommission").
+		Named(DecommissionControllerName).
 		For(&corev1.Node{}).
 		WithEventFilter(predicateFilter).
 		Complete(r)

--- a/internal/controller/eviction_controller.go
+++ b/internal/controller/eviction_controller.go
@@ -52,7 +52,8 @@ type EvictionReconciler struct {
 }
 
 const (
-	evictionFinalizerName = "eviction-controller.cloud.sap/finalizer"
+	evictionFinalizerName  = "eviction-controller.cloud.sap/finalizer"
+	EvictionControllerName = "eviction"
 )
 
 // +kubebuilder:rbac:groups=kvm.cloud.sap,resources=evictions,verbs=get;list;watch;create;update;patch;delete
@@ -565,6 +566,7 @@ func (r *EvictionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	return ctrl.NewControllerManagedBy(mgr).
+		Named(EvictionControllerName).
 		For(&kvmv1.Eviction{}).
 		Complete(r)
 }

--- a/internal/controller/hypervisor_controller.go
+++ b/internal/controller/hypervisor_controller.go
@@ -40,9 +40,10 @@ import (
 )
 
 const (
-	labelLifecycleMode     = "cobaltcore.cloud.sap/node-hypervisor-lifecycle"
-	annotationAggregates   = "nova.openstack.cloud.sap/aggregates"
-	annotationCustomTraits = "nova.openstack.cloud.sap/custom-traits"
+	labelLifecycleMode       = "cobaltcore.cloud.sap/node-hypervisor-lifecycle"
+	annotationAggregates     = "nova.openstack.cloud.sap/aggregates"
+	annotationCustomTraits   = "nova.openstack.cloud.sap/custom-traits"
+	HypervisorControllerName = "hypervisor"
 )
 
 var transferLabels = []string{
@@ -172,6 +173,7 @@ func (hv *HypervisorController) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
+		Named(HypervisorControllerName).
 		For(&corev1.Node{}).
 		WithEventFilter(novaVirtLabeledPredicate).
 		Complete(hv)

--- a/internal/controller/maintenance_controller.go
+++ b/internal/controller/maintenance_controller.go
@@ -55,6 +55,7 @@ const (
 	labelCriticalComponent          = "node.gardener.cloud/critical-component"
 	labelCriticalComponentsNotReady = "node.gardener.cloud/critical-components-not-ready"
 	valueReasonTerminating          = "terminating"
+	MaintenanceControllerName       = "maintenance"
 )
 
 // The counter-side in gardener is here:
@@ -260,7 +261,7 @@ func (r *MaintenanceController) SetupWithManager(mgr ctrl.Manager, namespace str
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		Named("maintenance").
+		Named(MaintenanceControllerName).
 		For(&corev1.Node{}).
 		Owns(&appsv1.Deployment{}). // trigger the r.Reconcile whenever an Own-ed deployment is created/updated/deleted
 		Owns(&policyv1.PodDisruptionBudget{}).

--- a/internal/controller/node_certificate_controller.go
+++ b/internal/controller/node_certificate_controller.go
@@ -36,6 +36,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+const (
+	NodeCertificateControllerName = "certificate"
+)
+
 type NodeCertificateController struct {
 	k8sclient.Client
 	Scheme     *runtime.Scheme
@@ -191,7 +195,7 @@ func (r *NodeCertificateController) SetupWithManager(mgr ctrl.Manager, namespace
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		Named("certificate").
+		Named(NodeCertificateControllerName).
 		For(&corev1.Node{}).
 		WithEventFilter(novaVirtLabeledPredicate).
 		Complete(r)

--- a/internal/controller/node_eviction_label_controller.go
+++ b/internal/controller/node_eviction_label_controller.go
@@ -37,8 +37,9 @@ import (
 )
 
 const (
-	disabledSuffix          = "-disabled"
-	labelMl2MechanismDriver = "neutron.openstack.cloud.sap/ml2-mechanism-driver"
+	disabledSuffix                  = "-disabled"
+	labelMl2MechanismDriver         = "neutron.openstack.cloud.sap/ml2-mechanism-driver"
+	NodeEvictionLabelControllerName = "nodeEvictionLabel"
 )
 
 type NodeEvictionLabelReconciler struct {
@@ -188,7 +189,7 @@ func (r *NodeEvictionLabelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	_ = logger.FromContext(ctx)
 
 	return ctrl.NewControllerManagedBy(mgr).
-		Named("nodeEvictionLabel").
+		Named(NodeEvictionLabelControllerName).
 		For(&corev1.Node{}).     // trigger the r.Reconcile whenever a node is created/updated/deleted.
 		Owns(&kvmv1.Eviction{}). // trigger the r.Reconcile whenever an Own-ed eviction is created/updated/deleted
 		Complete(r)

--- a/internal/controller/onboarding_controller.go
+++ b/internal/controller/onboarding_controller.go
@@ -65,6 +65,7 @@ const (
 	testImageName             = "cirros-d240801-kvm"
 	testPrefixName            = "ohooc-"
 	testVolumeType            = "kvm-pilot"
+	OnboardingControllerName  = "onboarding"
 )
 
 type OnboardingController struct {
@@ -575,7 +576,7 @@ func (r *OnboardingController) SetupWithManager(mgr ctrl.Manager) error {
 	r.testNetworkClient.ResourceBase = fmt.Sprintf("%vv2.0/", r.testNetworkClient.Endpoint)
 
 	return ctrl.NewControllerManagedBy(mgr).
-		Named("onboarding").
+		Named(OnboardingControllerName).
 		For(&kvmv1.Hypervisor{}).
 		Complete(r)
 }

--- a/internal/controller/traits_controller.go
+++ b/internal/controller/traits_controller.go
@@ -43,6 +43,7 @@ const (
 	ConditionTypeTraitsUpdated = "TraitsUpdated"
 	ConditionTraitsSuccess     = "Success"
 	ConditionTraitsFailed      = "Failed"
+	TraitsControllerName       = "traits"
 )
 
 type TraitsController struct {
@@ -171,7 +172,7 @@ func (tc *TraitsController) SetupWithManager(mgr ctrl.Manager) error {
 	tc.serviceClient.Microversion = "1.39" // yoga, or later
 
 	return ctrl.NewControllerManagedBy(mgr).
-		Named("traits").
+		Named(TraitsControllerName).
 		For(&kvmv1.Hypervisor{}).
 		Complete(tc)
 }


### PR DESCRIPTION
This allows us to pass the controller-name as a field-owner to better keep track who changed what.