### PR TITLE
Fix bug in cleanup: Only abort on error

### DIFF
--- a/internal/controller/onboarding_controller.go
+++ b/internal/controller/onboarding_controller.go
@@ -314,10 +314,9 @@ func (r *OnboardingController) completeOnboarding(ctx context.Context, host stri
 	for _, server := range serverList {
 		log.Info("deleting server", "name", server.Name)
 		err = servers.Delete(ctx, r.testComputeClient, server.ID).ExtractErr()
-		if gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
-			continue
+		if err != nil && gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, err
 	}
 
 	aggs, err := aggregatesByName(ctx, r.computeClient)


### PR DESCRIPTION
The code returns now if there hasn't been an error and the onboarding therefor doesn't continue.