### PR TITLE
TraitsController: Fix logic inversion on yield in traits

### DIFF
--- a/internal/controller/traits_controller.go
+++ b/internal/controller/traits_controller.go
@@ -73,7 +73,7 @@ func (tc *TraitsController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	customTraitsApplied := slices.Collect(func(yield func(string) bool) {
 		for _, trait := range hv.Status.Traits {
-			if strings.HasPrefix(trait, customPrefix) && yield(trait) {
+			if strings.HasPrefix(trait, customPrefix) && !yield(trait) {
 				return
 			}
 		}


### PR DESCRIPTION
A false returned from yield means no more items,
so we need to break there out of the loop.