### PR TITLE
Onboarding: Swallow not-found errors on delete

### DIFF
--- a/internal/controller/onboarding_controller.go
+++ b/internal/controller/onboarding_controller.go
@@ -315,7 +315,7 @@ func (r *OnboardingController) completeOnboarding(ctx context.Context, host stri
 	for _, server := range serverList {
 		log.Info("deleting server", "name", server.Name)
 		err = servers.Delete(ctx, r.testComputeClient, server.ID).ExtractErr()
-		if err != nil && gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+		if err != nil && !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
 			return ctrl.Result{}, err
 		}
 	}


### PR DESCRIPTION
The old code had a logic error. We do want to bubble up errors, but only the ones which are *not* a not-found error.