### PR TITLE
introduce --label-selector option to limit reconcilled objects

### DIFF
--- a/internal/controller/hypervisor_controller.go
+++ b/internal/controller/hypervisor_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kvmv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
+	"github.com/cobaltcore-dev/openstack-hypervisor-operator/internal/global"
 )
 
 const (
@@ -172,6 +173,11 @@ func (hv *HypervisorController) SetupWithManager(mgr ctrl.Manager) error {
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	// append the custom label selector from global config
+	if global.LabelSelector != "" {
+		transferLabels = append(transferLabels, global.LabelSelector)
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -1,0 +1,23 @@
+/*
+SPDX-FileCopyrightText: Copyright 2025 SAP SE or an SAP affiliate company and cobaltcore-dev contributors
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package global
+
+var (
+	// LabelSelector is a custom label that is used to select resources managed by the operator.
+	LabelSelector = ""
+)


### PR DESCRIPTION
before rollout with selector enable, it's important to delete all related objects (like evictions and hypervisors) since else there will be some strange effects (e.g. hypervisor CROs without the label are not found, but cannot be created because they already exist)