### PR TITLE
Make reconciler errors verbose debug logs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -38,6 +39,7 @@ import (
 
 	kvmv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
 	"github.com/cobaltcore-dev/openstack-hypervisor-operator/internal/controller"
+	"github.com/cobaltcore-dev/openstack-hypervisor-operator/internal/logger"
 
 	// +kubebuilder:scaffold:imports
 
@@ -85,11 +87,12 @@ func main() {
 
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctrl.SetLogger(logger.WrapLogger(zap.New(zap.UseFlagOptions(&opts))))
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -82,7 +82,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
+	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,67 @@
+/*
+SPDX-FileCopyrightText: Copyright 2024 SAP SE or an SAP affiliate company and cobaltcore-dev contributors
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"github.com/go-logr/logr"
+)
+
+type wrapper struct {
+	orig logr.LogSink
+}
+
+// Enabled implements logr.LogSink.
+func (w wrapper) Enabled(level int) bool {
+	return w.orig.Enabled(level)
+}
+
+// Error implements logr.LogSink.
+func (w wrapper) Error(err error, msg string, keysAndValues ...any) {
+	if msg == "Reconciler error" {
+		w.orig.Info(2, msg, append(keysAndValues, "error", err.Error())...)
+	} else {
+		w.orig.Error(err, msg, keysAndValues...)
+	}
+}
+
+// Info implements logr.LogSink.
+func (w wrapper) Info(level int, msg string, keysAndValues ...any) {
+	w.orig.Info(level, msg, keysAndValues...)
+}
+
+// Init implements logr.LogSink.
+func (w wrapper) Init(info logr.RuntimeInfo) {
+	w.orig.Init(info)
+}
+
+// WithName implements logr.LogSink.
+func (w wrapper) WithName(name string) logr.LogSink {
+	w.orig.WithName(name)
+	return w
+}
+
+// WithValues implements logr.LogSink.
+func (w wrapper) WithValues(keysAndValues ...any) logr.LogSink {
+	w.orig.WithValues(keysAndValues...)
+	return w
+}
+
+func WrapLogger(logger logr.Logger) logr.Logger {
+	orig := logger.GetSink()
+	return logger.WithSink(wrapper{orig})
+}


### PR DESCRIPTION
The reconciler errors are not terribly informative, they happen on a version conflict, and as well external services, but they are the way to trigger an exponential back-off.
Change them to a verbose output level, so we can still see them if requested.