### PR TITLE
AggregateLoggingProposal

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -96,7 +96,7 @@ func main() {
 	opts := ctrlzap.Options{
 		Development:     true,
 		TimeEncoder:     zapcore.ISO8601TimeEncoder,
-		ZapOpts:         []zap.Option{zap.WrapCore(logger.WrapCore)},
+		Encoder:         logger.NewSanitzeReconcileErrorEncoder(zapcore.EncoderConfig{}),
 		StacktraceLevel: zap.DPanicLevel,
 	}
 	opts.BindFlags(flag.CommandLine)

--- a/internal/utils/lifecycle_enabled.go
+++ b/internal/utils/lifecycle_enabled.go
@@ -1,0 +1,34 @@
+/*
+SPDX-FileCopyrightText: Copyright 2025 SAP SE or an SAP affiliate company and cobaltcore-dev contributors
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	kvmv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
+)
+
+var (
+	LifecycleEnabledPredicate = predicate.NewPredicateFuncs(func(object client.Object) bool {
+		if hv, ok := object.(*kvmv1.Hypervisor); ok {
+			return hv.Spec.LifecycleEnabled
+		}
+		return true
+	})
+)


### PR DESCRIPTION
This PR modifies the Code of https://github.com/cobaltcore-dev/openstack-hypervisor-operator/pull/161 to improve following points:
1. no need for extra error-log since instead of dropping Reconcile
   Errors, we format them nicely with the Encoder.
2. Function (like rewritten `setErrorCondition`) should not return the
   errors the've been invoked with - but only return errors if they
   fail. Also, it's an uneeded roundtrip to return the same error that
   has been passed by the caller.
3. Introduce `utils.LifecycleEnabledPredicate`, a predicate that will
   filter event's for hypervisors with LifecycleEnabled == True.

- **Aggregates: Use GenerationChangedPredicate and join errors**
- **Use zapEncoder for removing stacktrace of reconcilerrors, fixups**
