### PR TITLE
Print 'version'

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,6 +68,7 @@ func init() {
 }
 
 func main() {
+	var version bool
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
@@ -77,6 +78,8 @@ func main() {
 	var certificateNamespace string
 	var certificateIssuerName string
 
+	flag.BoolVar(&version, "version", false,
+		"Print the version and exit.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -101,6 +104,10 @@ func main() {
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if version {
+		os.Exit(0)
+	}
 
 	ctrl.SetLogger(ctrlzap.New(ctrlzap.UseFlagOptions(&opts)))
 


### PR DESCRIPTION
The build process expect that the -version flag is supported. Let's handle that by simply exiting for now.