### PR TITLE
[charts/config] remove hardcoded path for entrypoint

### DIFF
--- a/charts/openstack-hypervisor-operator/Chart.yaml
+++ b/charts/openstack-hypervisor-operator/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/openstack-hypervisor-operator/templates/deployment.yaml
+++ b/charts/openstack-hypervisor-operator/templates/deployment.yaml
@@ -21,8 +21,6 @@ spec:
     spec:
       containers:
       - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
-        command:
-        - /manager
         env:
         - name: OS_AUTH_URL
           value: {{ quote .Values.controllerManager.manager.env.osAuthUrl }}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,9 +58,7 @@ spec:
         # seccompProfile:
         #   type: RuntimeDefault
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
           - --leader-elect
           - --health-probe-bind-address=:8081
         env:


### PR DESCRIPTION
The binary is installed to /usr/bin by go-makefile-maker and set via
Dockerfile entrypoint, thus this patch removes the harded root path.
