### PR TITLE
Partially revert "Use zapEncoder"

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,7 +99,7 @@ func main() {
 	opts := ctrlzap.Options{
 		Development:     true,
 		TimeEncoder:     zapcore.ISO8601TimeEncoder,
-		Encoder:         logger.NewSanitzeReconcileErrorEncoder(zapcore.EncoderConfig{}),
+		ZapOpts:         []zap.Option{zap.WrapCore(logger.WrapCore)},
 		StacktraceLevel: zap.DPanicLevel,
 	}
 	opts.BindFlags(flag.CommandLine)


### PR DESCRIPTION
Use zap.WrapCore again, as it seems to work.

This partially reverts commit 9bfc3e088f4dd9df804b672777eab71bcca6f1d5.