### PR TITLE
[api] add maintenance spec and evicted status field as discussed

### DIFF
--- a/api/v1/hypervisor_types.go
+++ b/api/v1/hypervisor_types.go
@@ -74,6 +74,11 @@ type HypervisorSpec struct {
 	// +kubebuilder:default:=true
 	// InstallCertificate is used to enable the installations of the certificates via kvm-node-agent.
 	InstallCertificate bool `json:"installCertificate"`
+
+	// +kubebuilder:optional
+	// +kubebuilder:validation:Enum:="";manual;auto;ha
+	// Maintenance indicates whether the hypervisor is in maintenance mode.
+	Maintenance string `json:"maintenance,omitempty"`
 }
 
 type Instance struct {
@@ -183,6 +188,9 @@ type HypervisorStatus struct {
 
 	// InternalIP is the internal IP address of the hypervisor.
 	InternalIP string `json:"internalIp,omitempty"`
+
+	// Evicted indicates whether the hypervisor is evicted. (no instances left with active maintenance mode)
+	Evicted bool `json:"evicted,omitempty"`
 
 	// Represents the Hypervisor node conditions.
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`

--- a/applyconfigurations/api/v1/hypervisorspec.go
+++ b/applyconfigurations/api/v1/hypervisorspec.go
@@ -15,6 +15,7 @@ type HypervisorSpecApplyConfiguration struct {
 	HighAvailability             *bool    `json:"highAvailability,omitempty"`
 	CreateCertManagerCertificate *bool    `json:"createCertManagerCertificate,omitempty"`
 	InstallCertificate           *bool    `json:"installCertificate,omitempty"`
+	Maintenance                  *string  `json:"maintenance,omitempty"`
 }
 
 // HypervisorSpecApplyConfiguration constructs a declarative configuration of the HypervisorSpec type for use with
@@ -104,5 +105,13 @@ func (b *HypervisorSpecApplyConfiguration) WithCreateCertManagerCertificate(valu
 // If called multiple times, the InstallCertificate field is set to the value of the last call.
 func (b *HypervisorSpecApplyConfiguration) WithInstallCertificate(value bool) *HypervisorSpecApplyConfiguration {
 	b.InstallCertificate = &value
+	return b
+}
+
+// WithMaintenance sets the Maintenance field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Maintenance field is set to the value of the last call.
+func (b *HypervisorSpecApplyConfiguration) WithMaintenance(value string) *HypervisorSpecApplyConfiguration {
+	b.Maintenance = &value
 	return b
 }

--- a/applyconfigurations/api/v1/hypervisorstatus.go
+++ b/applyconfigurations/api/v1/hypervisorstatus.go
@@ -20,6 +20,7 @@ type HypervisorStatusApplyConfiguration struct {
 	Traits          []string                                  `json:"traits,omitempty"`
 	Aggregates      []string                                  `json:"aggregates,omitempty"`
 	InternalIP      *string                                   `json:"internalIp,omitempty"`
+	Evicted         *bool                                     `json:"evicted,omitempty"`
 	Conditions      []metav1.ConditionApplyConfiguration      `json:"conditions,omitempty"`
 	SpecHash        *string                                   `json:"specHash,omitempty"`
 }
@@ -124,6 +125,14 @@ func (b *HypervisorStatusApplyConfiguration) WithAggregates(values ...string) *H
 // If called multiple times, the InternalIP field is set to the value of the last call.
 func (b *HypervisorStatusApplyConfiguration) WithInternalIP(value string) *HypervisorStatusApplyConfiguration {
 	b.InternalIP = &value
+	return b
+}
+
+// WithEvicted sets the Evicted field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Evicted field is set to the value of the last call.
+func (b *HypervisorStatusApplyConfiguration) WithEvicted(value bool) *HypervisorStatusApplyConfiguration {
+	b.Evicted = &value
 	return b
 }
 

--- a/charts/openstack-hypervisor-operator/crds/hypervisor-crd.yaml
+++ b/charts/openstack-hypervisor-operator/crds/hypervisor-crd.yaml
@@ -138,6 +138,15 @@ spec:
                 description: LifecycleEnabled enables the lifecycle management of
                   the hypervisor via hypervisor-operator.
                 type: boolean
+              maintenance:
+                description: Maintenance indicates whether the hypervisor is in maintenance
+                  mode.
+                enum:
+                - ""
+                - manual
+                - auto
+                - ha
+                type: string
               reboot:
                 default: false
                 description: Reboot request an reboot after successful installation
@@ -251,6 +260,10 @@ spec:
                   - type
                   type: object
                 type: array
+              evicted:
+                description: Evicted indicates whether the hypervisor is evicted.
+                  (no instances left with active maintenance mode)
+                type: boolean
               hypervisorId:
                 description: HypervisorID is the unique identifier of the hypervisor
                   in OpenStack.

--- a/config/crd/bases/kvm.cloud.sap_hypervisors.yaml
+++ b/config/crd/bases/kvm.cloud.sap_hypervisors.yaml
@@ -139,6 +139,15 @@ spec:
                 description: LifecycleEnabled enables the lifecycle management of
                   the hypervisor via hypervisor-operator.
                 type: boolean
+              maintenance:
+                description: Maintenance indicates whether the hypervisor is in maintenance
+                  mode.
+                enum:
+                - ""
+                - manual
+                - auto
+                - ha
+                type: string
               reboot:
                 default: false
                 description: Reboot request an reboot after successful installation
@@ -252,6 +261,10 @@ spec:
                   - type
                   type: object
                 type: array
+              evicted:
+                description: Evicted indicates whether the hypervisor is evicted.
+                  (no instances left with active maintenance mode)
+                type: boolean
               hypervisorId:
                 description: HypervisorID is the unique identifier of the hypervisor
                   in OpenStack.


### PR DESCRIPTION
This adds the maintenance spec prop and evicted bool status which was
discussed in the the workshop
