### PR TITLE
Renamed MaintenanceController to GardenerNodeLifecycleController

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -253,7 +253,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controller.MaintenanceController{
+	if err = (&controller.GardenerNodeLifecycleController{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr, certificateNamespace); err != nil {

--- a/internal/controller/gardener_node_lifecycle_controller.go
+++ b/internal/controller/gardener_node_lifecycle_controller.go
@@ -41,7 +41,7 @@ import (
 	"github.com/cobaltcore-dev/openstack-hypervisor-operator/internal/openstack"
 )
 
-type MaintenanceController struct {
+type GardenerNodeLifecycleController struct {
 	k8sclient.Client
 	Scheme        *runtime.Scheme
 	serviceClient *gophercloud.ServiceClient
@@ -49,7 +49,6 @@ type MaintenanceController struct {
 }
 
 const (
-	labelManagedBy                  = "app.kubernetes.io/managed-by"
 	labelDeployment                 = "cobaltcore-maintenance-controller"
 	maintenancePodsNamespace        = "kube-system"
 	labelCriticalComponent          = "node.gardener.cloud/critical-component"
@@ -65,7 +64,7 @@ const (
 // +kubebuilder:rbac:groups="apps",resources=deployments,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="policy",resources=poddisruptionbudgets,verbs=create;delete;get;list;patch;update;watch
 
-func (r *MaintenanceController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *GardenerNodeLifecycleController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logger.FromContext(ctx).WithName(req.Name)
 	ctx = logger.IntoContext(ctx, log)
 
@@ -115,7 +114,7 @@ func (r *MaintenanceController) Reconcile(ctx context.Context, req ctrl.Request)
 	return ctrl.Result{}, nil
 }
 
-func (r *MaintenanceController) ensureBlockingPodDisruptionBudget(ctx context.Context, node *corev1.Node, minAvailable int32) error {
+func (r *GardenerNodeLifecycleController) ensureBlockingPodDisruptionBudget(ctx context.Context, node *corev1.Node, minAvailable int32) error {
 	name := nameForNode(node)
 	podDisruptionBudget := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
@@ -165,7 +164,7 @@ func labelsForNode(node *corev1.Node) map[string]string {
 	}
 }
 
-func (r *MaintenanceController) ensureSignallingDeployment(ctx context.Context, node *corev1.Node, scale int32, ready bool) error {
+func (r *GardenerNodeLifecycleController) ensureSignallingDeployment(ctx context.Context, node *corev1.Node, scale int32, ready bool) error {
 	name := nameForNode(node)
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -250,7 +249,7 @@ func (r *MaintenanceController) ensureSignallingDeployment(ctx context.Context, 
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *MaintenanceController) SetupWithManager(mgr ctrl.Manager, namespace string) error {
+func (r *GardenerNodeLifecycleController) SetupWithManager(mgr ctrl.Manager, namespace string) error {
 	ctx := context.Background()
 	_ = logger.FromContext(ctx)
 	r.namespace = namespace

--- a/internal/controller/gardener_node_lifecycle_controller_test.go
+++ b/internal/controller/gardener_node_lifecycle_controller_test.go
@@ -27,12 +27,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Maintenance Controller", func() {
+var _ = Describe("Gardener Maintenance Controller", func() {
 	const nodeName = "node-test"
-	var maintenanceController *MaintenanceController
+	var controller *GardenerNodeLifecycleController
 
 	BeforeEach(func() {
-		maintenanceController = &MaintenanceController{
+		controller = &GardenerNodeLifecycleController{
 			Client: k8sClient,
 			Scheme: k8sClient.Scheme(),
 		}
@@ -64,7 +64,7 @@ var _ = Describe("Maintenance Controller", func() {
 			}
 
 			By("Reconciling the created resource")
-			_, err := maintenanceController.Reconcile(ctx, req)
+			_, err := controller.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
MaintenanceController is somewhat unspecific, and we have now a maintenance field in the hypervisor spec, so this might get even more confusing.

As the controller actually signals gardener information about the lifcycle of the node, let's call it GardenerNodeLifecycleController.