### PR TITLE
NodeLabelEviction: Transport labels to eviction

### DIFF
--- a/internal/controller/hypervisor_controller.go
+++ b/internal/controller/hypervisor_controller.go
@@ -223,6 +223,10 @@ func transportAggregatesAndTraits(node *metav1.ObjectMeta, hypervisor *kvmv1.Hyp
 
 // transportLabels transports relevant labels from the source to the destination metadata
 func transportLabels(source, destination *metav1.ObjectMeta) {
+	// If destination is created "manually" (not gotten from the api), this might be nil
+	if destination.Labels == nil {
+		destination.Labels = make(map[string]string)
+	}
 	// transfer labels
 	for _, transferLabel := range transferLabels {
 		if label, ok := source.Labels[transferLabel]; ok {

--- a/internal/controller/node_eviction_label_controller.go
+++ b/internal/controller/node_eviction_label_controller.go
@@ -140,6 +140,7 @@ func (r *NodeEvictionLabelReconciler) reconcileEviction(ctx context.Context, evi
 			Reason:     fmt.Sprintf("openstack-hypervisor-operator: label %v=%v", labelEvictionRequired, maintenanceValue),
 		}
 
+		transportLabels(&hypervisor.ObjectMeta, &eviction.ObjectMeta)
 		if err = r.Create(ctx, eviction); err != nil {
 			return "", fmt.Errorf("failed to create eviction due to %w", err)
 		}


### PR DESCRIPTION
So we can split up the controller by label, we need this here too.