### PR TITLE
removing the arm build as it takes 27mins

### DIFF
--- a/.github/workflows/container-registry-ghcr.yaml
+++ b/.github/workflows/container-registry-ghcr.yaml
@@ -51,6 +51,6 @@ jobs:
         with:
           context: .
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -40,7 +40,7 @@ githubWorkflow:
     queries: security-extended
   pushContainerToGhcr:
     enabled: true
-    platforms: "linux/amd64,linux/arm64"
+    platforms: "linux/amd64"
     tagStrategy:
       - latest
       - semver


### PR DESCRIPTION
there is no arm support for the cloud-hypervisor driver in libvirt anyways