### PR TITLE
Add crd only chart, that installs CRDs unconditionally

### DIFF
--- a/.github/workflows/helm-crd-oci-package-ghcr.yaml
+++ b/.github/workflows/helm-crd-oci-package-ghcr.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company
+# SPDX-License-Identifier: Apache-2.0
+
+name: Helm CRD OCI Package GHCR
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/openstack-hypervisor-operator/crds/**'
+  workflow_dispatch: {}
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build-and-push-helm-crd-package:
+    name: Build and publish Helm CRD Chart OCI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+      - name: Sync CRDs from main chart
+        run: cp charts/openstack-hypervisor-operator/crds/*.yaml charts/openstack-hypervisor-operator-crd/templates/
+      - name: Lint Helm Chart
+        run: helm lint charts/openstack-hypervisor-operator-crd
+      - name: Package Helm Chart
+        run: |
+          # Use run number to auto-increment version on each CRD change
+          VERSION="1.0.${{ github.run_number }}"
+          echo "Running helm package with version $VERSION"
+          helm package charts/openstack-hypervisor-operator-crd --destination ./chart --version "$VERSION"
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+      - name: Push Helm Chart to ghcr.io
+        run: helm push ./chart/*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/charts/openstack-hypervisor-operator-crd/.helmignore
+++ b/charts/openstack-hypervisor-operator-crd/.helmignore
@@ -1,0 +1,14 @@
+# Patterns to ignore when building packages.
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*~
+.git
+.gitignore
+.bzr
+.bzrignore
+.hg
+.hgignore
+.svn
+.empty

--- a/charts/openstack-hypervisor-operator-crd/Chart.yaml
+++ b/charts/openstack-hypervisor-operator-crd/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: openstack-hypervisor-operator-crd
+description: CRDs for the OpenStack Hypervisor Operator
+appVersion: latest
+version: 1.0.0
+type: application


### PR DESCRIPTION
not happy with that, but it seems that's the preferable way currently.
Chart is auto-version on every CRD changed and pushed to ghcr.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Helm chart providing the operator's CRDs, ready for installation.

* **Chores**
  * CI workflow added to package and publish the CRD Helm chart to the container registry (supports push and manual runs).
  * Helm packaging ignores common temp/editor files and includes chart metadata for versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->