### PR TITLE
EvictionController: Fix potential panic on header access

### DIFF
--- a/internal/controller/eviction_controller.go
+++ b/internal/controller/eviction_controller.go
@@ -368,7 +368,7 @@ func (r *EvictionReconciler) liveMigrate(ctx context.Context, uuid string, evict
 		return err
 	}
 
-	log.Info("Live migrating server", "server", uuid, "source", eviction.Spec.Hypervisor, "X-Openstack-Request-Id", res.Header["X-Openstack-Request-Id"][0])
+	log.Info("Live migrating server", "server", uuid, "source", eviction.Spec.Hypervisor, "X-Openstack-Request-Id", res.Header.Get("X-Openstack-Request-Id"))
 	return nil
 }
 
@@ -387,7 +387,7 @@ func (r *EvictionReconciler) coldMigrate(ctx context.Context, uuid string, evict
 		return err
 	}
 
-	log.Info("Cold-migrating server", "server", uuid, "source", eviction.Spec.Hypervisor, "X-Openstack-Request-Id", res.Header["X-Openstack-Request-Id"][0])
+	log.Info("Cold-migrating server", "server", uuid, "source", eviction.Spec.Hypervisor, "X-Openstack-Request-Id", res.Header.Get("X-Openstack-Request-Id"))
 	return nil
 }
 


### PR DESCRIPTION
Use Header.Get() instead of direct array indexing to safely access
X-Openstack-Request-Id header. This prevents panic if the header
is missing or empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of migration logging to safely handle missing OpenStack request identifiers, preventing potential issues when headers are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->