### PR TITLE
EvictionController: Fix unused logger context return value

### DIFF
--- a/internal/controller/eviction_controller.go
+++ b/internal/controller/eviction_controller.go
@@ -241,7 +241,7 @@ func (r *EvictionReconciler) evictNext(ctx context.Context, eviction *kvmv1.Evic
 	instances := &eviction.Status.OutstandingInstances
 	uuid := (*instances)[len(*instances)-1]
 	log := logger.FromContext(ctx).WithName("Evict").WithValues("server", uuid)
-	logger.IntoContext(ctx, log)
+	ctx = logger.IntoContext(ctx, log)
 
 	res := servers.Get(ctx, r.computeClient, uuid)
 	vm, err := res.Extract()
@@ -255,7 +255,7 @@ func (r *EvictionReconciler) evictNext(ctx context.Context, eviction *kvmv1.Evic
 	}
 
 	log = log.WithValues("server_status", vm.Status)
-	logger.IntoContext(ctx, log)
+	ctx = logger.IntoContext(ctx, log)
 
 	// First, check the transient statuses
 	switch vm.Status {


### PR DESCRIPTION
Assign the return value of logger.IntoContext() back to ctx so that subsequent calls using ctx will have the enriched logger with additional fields (server, server_status).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logging context propagation during eviction operations to ensure subsequent operations and log statements correctly maintain context information throughout the operation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->