### PR TITLE
[workflows] release strategy edge broke semver tagging releases.

### DIFF
--- a/.github/workflows/container-registry-ghcr.yaml
+++ b/.github/workflows/container-registry-ghcr.yaml
@@ -9,8 +9,8 @@
 name: Container Registry GHCR
 "on":
   push:
-    branches:
-      - main
+    tags:
+      - '*'
   workflow_dispatch: {}
 permissions:
   contents: read
@@ -34,8 +34,6 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            # https://github.com/docker/metadata-action#typeedge
-            type=edge
             # https://github.com/docker/metadata-action#latest-tag
             type=raw,value=latest,enable={{is_default_branch}}
             # https://github.com/docker/metadata-action#typesemver

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -41,7 +41,6 @@ githubWorkflow:
     enabled: true
     platforms: "linux/amd64,linux/arm64"
     tagStrategy:
-      - edge
       - latest
       - semver
       - sha

--- a/charts/openstack-hypervisor-operator/templates/deployment.yaml
+++ b/charts/openstack-hypervisor-operator/templates/deployment.yaml
@@ -47,8 +47,7 @@ spec:
           value: {{ quote .Values.controllerManager.manager.env.labelSelector }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
-        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Chart.AppVersion }}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
We don't use the edge label activly anyway.

Also force usage of AppVersion as image version since it seem to
fallback using latest ever if overriden via helm.
