### PR TITLE
Improve onboarding condition messages for better diagnostics

### DIFF
--- a/internal/controller/ready/controller.go
+++ b/internal/controller/ready/controller.go
@@ -184,11 +184,17 @@ func ComputeReadyCondition(hv *kvmv1.Hypervisor) metav1.Condition {
 
 	// Priority 5: Onboarding not started, aborted, or not succeeded
 	if onboardingCondition == nil {
+		message := "Onboarding not started"
+		if !hv.Spec.LifecycleEnabled {
+			message = "Onboarding not started: lifecycle management is disabled"
+		} else if hv.Status.HypervisorID == "" || hv.Status.ServiceID == "" {
+			message = "Onboarding not started: waiting for nova-compute to register the hypervisor in Nova (HypervisorID/ServiceID not yet available)"
+		}
 		return metav1.Condition{
 			Type:    kvmv1.ConditionTypeReady,
 			Status:  metav1.ConditionFalse,
 			Reason:  kvmv1.ConditionReasonOnboarding,
-			Message: "Onboarding not started",
+			Message: message,
 		}
 	}
 

--- a/internal/controller/ready/controller_test.go
+++ b/internal/controller/ready/controller_test.go
@@ -278,13 +278,39 @@ var _ = Describe("ComputeReadyCondition", func() {
 	})
 
 	Context("Priority 5: Onboarding not started/aborted/not succeeded", func() {
-		It("should return Ready=False when no onboarding condition exists", func() {
+		It("should mention lifecycle disabled when lifecycleEnabled is false", func() {
+			hv.Spec.LifecycleEnabled = false
+
 			result := ComputeReadyCondition(hv)
 
 			Expect(result.Type).To(Equal(kvmv1.ConditionTypeReady))
 			Expect(result.Status).To(Equal(metav1.ConditionFalse))
 			Expect(result.Reason).To(Equal(kvmv1.ConditionReasonOnboarding))
-			Expect(result.Message).To(ContainSubstring("not started"))
+			Expect(result.Message).To(ContainSubstring("lifecycle management is disabled"))
+		})
+
+		It("should mention waiting for nova-compute when HypervisorID/ServiceID are missing", func() {
+			hv.Spec.LifecycleEnabled = true
+
+			result := ComputeReadyCondition(hv)
+
+			Expect(result.Type).To(Equal(kvmv1.ConditionTypeReady))
+			Expect(result.Status).To(Equal(metav1.ConditionFalse))
+			Expect(result.Reason).To(Equal(kvmv1.ConditionReasonOnboarding))
+			Expect(result.Message).To(ContainSubstring("waiting for nova-compute"))
+		})
+
+		It("should return generic not started when lifecycle is enabled and IDs are present", func() {
+			hv.Spec.LifecycleEnabled = true
+			hv.Status.HypervisorID = "some-id"
+			hv.Status.ServiceID = "some-service-id"
+
+			result := ComputeReadyCondition(hv)
+
+			Expect(result.Type).To(Equal(kvmv1.ConditionTypeReady))
+			Expect(result.Status).To(Equal(metav1.ConditionFalse))
+			Expect(result.Reason).To(Equal(kvmv1.ConditionReasonOnboarding))
+			Expect(result.Message).To(Equal("Onboarding not started"))
 		})
 
 		It("should return Ready=False when onboarding was aborted", func() {


### PR DESCRIPTION
Instead of the generic "Onboarding not started" message, the Ready condition now reports the specific reason: lifecycle management being disabled or nova-compute not having registered the hypervisor yet (missing HypervisorID/ServiceID). This helps operators quickly identify root causes like DNS or RabbitMQ connectivity issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Hypervisor onboarding status messages now provide context-specific guidance based on lifecycle configuration and service availability state, offering clearer information about what's needed rather than generic messaging.

* **Tests**
  * Expanded test coverage for onboarding status conditions across different configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->