### PR TITLE
Fix SSA for conditions

### DIFF
--- a/api/v1/eviction_types.go
+++ b/api/v1/eviction_types.go
@@ -83,6 +83,8 @@ type EvictionStatus struct {
 	OutstandingInstances []string `json:"outstandingInstances"`
 
 	// Conditions is an array of current conditions
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/v1/hypervisor_types.go
+++ b/api/v1/hypervisor_types.go
@@ -553,7 +553,9 @@ type HypervisorStatus struct {
 	Evicted bool `json:"evicted,omitempty"`
 
 	// Represents the Hypervisor node conditions.
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	SpecHash string `json:"specHash,omitempty"`
 }

--- a/charts/openstack-hypervisor-operator/crds/kvm.cloud.sap_evictions.yaml
+++ b/charts/openstack-hypervisor-operator/crds/kvm.cloud.sap_evictions.yaml
@@ -129,6 +129,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               hypervisorServiceId:
                 type: string
               outstandingInstances:

--- a/charts/openstack-hypervisor-operator/crds/kvm.cloud.sap_hypervisors.yaml
+++ b/charts/openstack-hypervisor-operator/crds/kvm.cloud.sap_hypervisors.yaml
@@ -468,6 +468,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               domainCapabilities:
                 description: |-
                   Auto-discovered domain capabilities relevant to check if a VM


### PR DESCRIPTION
The struct tags on the conditions like `patchStrategy:merge` are the used by the k8s server proper, but they have no effect in controller-runtime. The corresponding annotations have been set instead, and you can see the effect in the generated crd declaration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced status condition handling for Eviction and Hypervisor resources to enable more efficient updates and improved support for concurrent modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->