### PR TITLE
feat: add playbook labels to all alerts

### DIFF
--- a/charts/openstack-hypervisor-operator/alerts/eviction.yaml
+++ b/charts/openstack-hypervisor-operator/alerts/eviction.yaml
@@ -11,6 +11,7 @@ groups:
     labels:
       severity: warning
       type: hypervisor_operator
+      playbook: docs/compute/kvm/playbooks/evictionfailed
     annotations:
       summary: "Eviction {{ $labels.name }} has failed"
       description: "The eviction {{ $labels.name }} for hypervisor {{ $labels.hypervisor }} has reached a terminal failure state. Manual intervention is required — check if the hypervisor exists in OpenStack."
@@ -24,6 +25,7 @@ groups:
     labels:
       severity: warning
       type: hypervisor_operator
+      playbook: docs/compute/kvm/playbooks/evictionmigrationfailing
     annotations:
       summary: "Eviction {{ $labels.name }} has failing instance migrations for over 1 hour"
       description: "The eviction {{ $labels.name }} has had MigratingInstance=Failed for more than 1 hour while still running. Instances may be in ERROR state, blocking eviction progress."
@@ -37,6 +39,7 @@ groups:
     labels:
       severity: warning
       type: hypervisor_operator
+      playbook: docs/compute/kvm/playbooks/evictionoutstandingram
     annotations:
       summary: "Eviction {{ $labels.name }} has outstanding RAM for over 6 hours"
       description: "The eviction {{ $labels.name }} has had {{ $value }}MB of outstanding RAM for more than 6 hours. Check for stuck live-migrations or instances that cannot be moved."

--- a/charts/openstack-hypervisor-operator/alerts/operator.yaml
+++ b/charts/openstack-hypervisor-operator/alerts/operator.yaml
@@ -11,6 +11,7 @@ groups:
     labels:
       severity: warning
       type: hypervisor_operator
+      playbook: docs/compute/kvm/playbooks/hypervisoronboardingstuck
     annotations:
       summary: "Hypervisor {{ $labels.name }} onboarding stuck for over 1 hour"
       description: "The hypervisor {{ $labels.name }} in zone {{ $labels.zone }} has been onboarding for more than 1 hour. Check nova registration, test VM status, or trait/aggregate sync."
@@ -22,6 +23,7 @@ groups:
     labels:
       severity: warning
       type: hypervisor_operator
+      playbook: docs/compute/kvm/playbooks/hypervisorevictionstuck
     annotations:
       summary: "Hypervisor {{ $labels.name }} eviction running for over 4 hours"
       description: "The hypervisor {{ $labels.name }} in zone {{ $labels.zone }} has had an active eviction for more than 4 hours. Check for stuck live-migrations or failed VMs."
@@ -35,6 +37,7 @@ groups:
     labels:
       severity: info
       type: hypervisor_operator
+      playbook: docs/compute/kvm/playbooks/hypervisorevictedtoolong
     annotations:
       summary: "Hypervisor {{ $labels.name }} has been evicted for over 7 days"
       description: "The hypervisor {{ $labels.name }} in zone {{ $labels.zone }} has been evicted for more than 7 days without being offboarded. Consider re-enabling or decommissioning."
@@ -50,6 +53,7 @@ groups:
     labels:
       severity: warning
       type: hypervisor_operator
+      playbook: docs/compute/kvm/playbooks/hypervisortraitsyncfailed
     annotations:
       summary: "Hypervisor {{ $labels.name }} trait sync has been failing"
       description: "The hypervisor {{ $labels.name }} in zone {{ $labels.zone }} has had TraitsUpdated=False for more than 30 minutes outside of onboarding. Check OpenStack Placement API connectivity."
@@ -65,6 +69,7 @@ groups:
     labels:
       severity: warning
       type: hypervisor_operator
+      playbook: docs/compute/kvm/playbooks/hypervisoraggregatesyncfailed
     annotations:
       summary: "Hypervisor {{ $labels.name }} aggregate sync has been failing"
       description: "The hypervisor {{ $labels.name }} in zone {{ $labels.zone }} has had AggregatesUpdated=False for more than 30 minutes outside of onboarding and eviction. Check OpenStack Nova API connectivity."
@@ -78,6 +83,7 @@ groups:
     labels:
       severity: warning
       type: hypervisor_operator
+      playbook: docs/compute/kvm/playbooks/hypervisorreconcileerrors
     annotations:
       summary: "Hypervisor operator controller {{ $labels.controller }} has persistent reconcile errors"
       description: "The controller {{ $labels.controller }} has been producing sustained reconciliation errors for more than 15 minutes."
@@ -89,6 +95,7 @@ groups:
     labels:
       severity: critical
       type: hypervisor_operator
+      playbook: docs/compute/kvm/playbooks/hypervisoroperatordown
     annotations:
       summary: "Hypervisor operator is down"
       description: "The hypervisor operator metrics endpoint has been unreachable for more than 5 minutes."

--- a/charts/openstack-hypervisor-operator/templates/servicemonitor.yaml
+++ b/charts/openstack-hypervisor-operator/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and cobaltcore-dev contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openstack-hypervisor-operator.fullname" . }}
+  labels:
+  {{- include "openstack-hypervisor-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceMonitor.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+    {{- include "openstack-hypervisor-operator.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: https
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/openstack-hypervisor-operator/values.yaml
+++ b/charts/openstack-hypervisor-operator/values.yaml
@@ -45,6 +45,10 @@ metricsService:
     protocol: TCP
     targetPort: 8443
   type: ClusterIP
+serviceMonitor:
+  enabled: true
+  labels: {}
+  interval: 60s
 secret:
   servicePassword: ""
 serviceAccount:


### PR DESCRIPTION
## Summary

- Adds `playbook:` label to all 10 alerts (7 in operator.yaml, 3 in eviction.yaml)
- Labels point to existing playbook pages on operations.global.cloud.sap

## Alerts updated

| Alert | Playbook slug |
|-------|--------------|
| HypervisorOnboardingStuck | `hypervisoronboardingstuck` |
| HypervisorEvictionStuck | `hypervisorevictionstuck` |
| HypervisorEvictedTooLong | `hypervisorevictedtoolong` |
| HypervisorTraitSyncFailed | `hypervisortraitsyncfailed` |
| HypervisorAggregateSyncFailed | `hypervisoraggregatesyncfailed` |
| HypervisorOperatorReconcileErrors | `hypervisorreconcileerrors` |
| HypervisorOperatorDown | `hypervisoroperatordown` |
| EvictionFailed | `evictionfailed` |
| EvictionMigrationFailing | `evictionmigrationfailing` |
| EvictionOutstandingRamHigh | `evictionoutstandingram` |

Ref: PlusOne/CPE-KVM#236

## Test plan

- [x] No changes to alert expressions or thresholds — labels only
- [ ] Deploy to QA and verify playbook links render in Alertmanager/Slack notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Eviction and hypervisor operator alerts now include associated playbook references for streamlined incident response and troubleshooting guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cobaltcore-dev/openstack-hypervisor-operator/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->