### PR TITLE
Scope Deployment and PodDisruptionBudget cache to maintenance objects

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,9 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -179,7 +181,24 @@ func main() {
 		bininfo.CommitOr("edge"))
 
 	leaderElectionID := "4c28796a.cloud.sap"
-	var cacheOptions cache.Options
+	// Deployments and PodDisruptionBudgets owned by the maintenance controller
+	// always live in kube-system and carry the cobaltcore-maintenance-controller
+	// label; restrict the cache to exactly those objects.
+	maintenanceSelector, err := labels.Parse(controller.MaintenanceLabelKey)
+	if err != nil {
+		setupLog.Error(err, "unable to parse maintenance label selector")
+		os.Exit(1)
+	}
+	maintenanceCacheConfig := cache.ByObject{
+		Namespaces: map[string]cache.Config{controller.MaintenanceNamespace: {}},
+		Label:      maintenanceSelector,
+	}
+	cacheOptions := cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&appsv1.Deployment{}:            maintenanceCacheConfig,
+			&policyv1.PodDisruptionBudget{}: maintenanceCacheConfig,
+		},
+	}
 	if global.LabelSelector != "" {
 		setupLog.Info("setting up cache with label selector", "selector", global.LabelSelector)
 		selector, err := labels.Parse(global.LabelSelector)
@@ -188,16 +207,8 @@ func main() {
 			os.Exit(1)
 		}
 
-		cacheOptions = cache.Options{
-			ByObject: map[client.Object]cache.ByObject{
-				&corev1.Node{}: {
-					Label: selector,
-				},
-				&kvmv1.Hypervisor{}: {
-					Label: selector,
-				},
-			},
-		}
+		cacheOptions.ByObject[&corev1.Node{}] = cache.ByObject{Label: selector}
+		cacheOptions.ByObject[&kvmv1.Hypervisor{}] = cache.ByObject{Label: selector}
 
 		h := sha256.New()
 		h.Write([]byte(leaderElectionID)) // Seed it with something "unique" to the project

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -21,4 +21,11 @@ package controller
 const (
 	labelHypervisor   = "nova.openstack.cloud.sap/virt-driver"
 	testAggregateName = "tenant_filter_tests"
+
+	// MaintenanceLabelKey is the label key applied to Deployments and
+	// PodDisruptionBudgets owned by the maintenance controller.
+	MaintenanceLabelKey = "cobaltcore-maintenance-controller"
+	// MaintenanceNamespace is the namespace where the maintenance controller
+	// creates its Deployments and PodDisruptionBudgets.
+	MaintenanceNamespace = "kube-system"
 )

--- a/internal/controller/gardener_node_lifecycle_controller.go
+++ b/internal/controller/gardener_node_lifecycle_controller.go
@@ -47,8 +47,6 @@ type GardenerNodeLifecycleController struct {
 }
 
 const (
-	labelDeployment           = "cobaltcore-maintenance-controller"
-	maintenancePodsNamespace  = "kube-system"
 	labelCriticalComponent    = "node.gardener.cloud/critical-component"
 	valueReasonTerminating    = "terminating"
 	MaintenanceControllerName = "maintenance"
@@ -123,7 +121,7 @@ func (r *GardenerNodeLifecycleController) ensureBlockingPodDisruptionBudget(ctx 
 		return err
 	}
 
-	podDisruptionBudget := policyv1ac.PodDisruptionBudget(name, maintenancePodsNamespace).
+	podDisruptionBudget := policyv1ac.PodDisruptionBudget(name, MaintenanceNamespace).
 		WithLabels(nodeLabels).
 		WithOwnerReferences(OwnerReference(node, &gvk)).
 		WithSpec(policyv1ac.PodDisruptionBudgetSpec().
@@ -155,7 +153,7 @@ func nameForNode(node *corev1.Node) string {
 
 func labelsForNode(node *corev1.Node) map[string]string {
 	return map[string]string{
-		labelDeployment: nameForNode(node),
+		MaintenanceLabelKey: nameForNode(node),
 	}
 }
 
@@ -178,7 +176,7 @@ func (r *GardenerNodeLifecycleController) ensureSignallingDeployment(ctx context
 		return err
 	}
 
-	deployment := apps1ac.Deployment(name, maintenancePodsNamespace).
+	deployment := apps1ac.Deployment(name, MaintenanceNamespace).
 		WithOwnerReferences(OwnerReference(node, &gvk)).
 		WithLabels(labels).
 		WithSpec(apps1ac.DeploymentSpec().


### PR DESCRIPTION
Without `ByObject` entries these are cached cluster-wide. The
maintenance controller only creates them in `kube-system` with the
`cobaltcore-maintenance-controller` label; restrict the cache to
exactly those objects.