### PR TITLE
Set GOMEMLIMIT from container memory limit

### DIFF
--- a/charts/openstack-hypervisor-operator/templates/deployment.yaml
+++ b/charts/openstack-hypervisor-operator/templates/deployment.yaml
@@ -47,6 +47,11 @@ spec:
           value: {{ quote .Values.controllerManager.manager.env.labelSelector }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+              divisor: "1"
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Chart.AppVersion }}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Without `GOMEMLIMIT` the Go GC is unaware of the container limit and may
let the heap grow until the kernel OOM-kills the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The manager now automatically adjusts its Go memory limit based on the container memory limit, helping the service operate more predictably under constrained resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->