### PR TITLE
Improve signal handling in GardenerNodeLifecycleController

### DIFF
--- a/internal/controller/gardener_node_lifecycle_controller.go
+++ b/internal/controller/gardener_node_lifecycle_controller.go
@@ -207,7 +207,7 @@ func (r *GardenerNodeLifecycleController) ensureSignallingDeployment(ctx context
 						corev1ac.Container().
 							WithName("sleep").
 							WithImage("keppel.global.cloud.sap/ccloud-dockerhub-mirror/library/busybox:latest").
-							WithCommand("sleep", "inf").
+							WithCommand("sh", "-c", "trap 'exit 0' TERM; sleep infinity & wait").
 							WithStartupProbe(corev1ac.Probe().
 								WithExec(corev1ac.ExecAction().WithCommand(command)).
 								WithInitialDelaySeconds(0).


### PR DESCRIPTION
So far ending the signal deployment/pod took more time than necessary
because the sleep command was not handling the TERM signal properly.
This change modifies the command to handle the TERM signal and exit
gracefully, allowing for a faster shutdown of the container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown behavior for the signalling container so it handles termination signals cleanly and exits without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->