### PR TITLE
Hypervisor: Drop FieldOwner from Create

### DIFF
--- a/internal/controller/hypervisor_controller.go
+++ b/internal/controller/hypervisor_controller.go
@@ -194,7 +194,7 @@ func (hv *HypervisorController) Reconcile(ctx context.Context, req ctrl.Request)
 		hypervisor.Spec.Maintenance = kvmv1.MaintenanceTermination
 	}
 
-	if err := hv.Create(ctx, hypervisor, k8sclient.FieldOwner(HypervisorControllerName)); err != nil {
+	if err := hv.Create(ctx, hypervisor); err != nil {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
Drop the `FieldOwner` option from the `Create` call in `HypervisorController`. Field ownership is only meaningful for `Apply`/`Patch`; passing it on `Create` is a no-op that creates noise in managed-fields.

Part of the [branch stack](https://github.com/cobaltcore-dev/openstack-hypervisor-operator/pulls) being reorganized for reviewability. Independent of SSA migration — can be merged at any time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hypervisor resource creation by removing an unnecessary ownership setting.
  * Hypervisor reconciliation behavior remains unchanged after creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->