### PR TITLE
Regenerate apply configurations with controller-gen v0.21.0

### DIFF
--- a/api/v1/hypervisor_types.go
+++ b/api/v1/hypervisor_types.go
@@ -168,12 +168,13 @@ type HypervisorSpec struct {
 	HighAvailability bool `json:"highAvailability"`
 
 	// +kubebuilder:default:=false
-	// Requires issuing a certificate from cert-manager for the hypervisor, to be used for
-	// secure communication with the libvirt API.
+	// CreateCertManagerCertificate requests that a certificate be issued from
+	// cert-manager for the hypervisor, to be used for secure communication
+	// with the libvirt API.
 	CreateCertManagerCertificate bool `json:"createCertManagerCertificate"`
 
 	// +kubebuilder:default:=true
-	// InstallCertificate is used to enable the installation of the certificates via kvm-node-agent.
+	// InstallCertificate enables installation of certificates via kvm-node-agent.
 	InstallCertificate bool `json:"installCertificate"`
 
 	// +kubebuilder:optional

--- a/api/v1/hypervisor_types.go
+++ b/api/v1/hypervisor_types.go
@@ -115,11 +115,11 @@ type HypervisorSpec struct {
 	OperatingSystemVersion string `json:"version,omitempty"`
 
 	// +kubebuilder:default:=false
-	// Reboot request an reboot after successful installation of an upgrade.
+	// Reboot requests a reboot after successful installation of an upgrade.
 	Reboot bool `json:"reboot"`
 
 	// +kubebuilder:default:=true
-	// EvacuateOnReboot request an evacuation of all instances before reboot.
+	// EvacuateOnReboot requests an evacuation of all instances before reboot.
 	EvacuateOnReboot bool `json:"evacuateOnReboot"`
 
 	// +kubebuilder:default:=true
@@ -168,12 +168,12 @@ type HypervisorSpec struct {
 	HighAvailability bool `json:"highAvailability"`
 
 	// +kubebuilder:default:=false
-	// Require to issue a certificate from cert-manager for the hypervisor, to be used for
+	// Requires issuing a certificate from cert-manager for the hypervisor, to be used for
 	// secure communication with the libvirt API.
 	CreateCertManagerCertificate bool `json:"createCertManagerCertificate"`
 
 	// +kubebuilder:default:=true
-	// InstallCertificate is used to enable the installations of the certificates via kvm-node-agent.
+	// InstallCertificate is used to enable the installation of the certificates via kvm-node-agent.
 	InstallCertificate bool `json:"installCertificate"`
 
 	// +kubebuilder:optional
@@ -401,7 +401,7 @@ type DomainCapabilities struct {
 	// Supported devices for domains.
 	//
 	// The format of this list is the device type, and if specified, a specific
-	// model. For example, the take the following xml domain device definition:
+	// model. For example, take the following xml domain device definition:
 	//
 	// <video supported='yes'>
 	//   <enum name='modelType'>
@@ -417,7 +417,7 @@ type DomainCapabilities struct {
 	// Supported cpu modes for domains.
 	//
 	// The format of this list is cpu mode, and if specified, a specific
-	// submode. For example, the take the following xml domain cpu definition:
+	// submode. For example, take the following xml domain cpu definition:
 	//
 	// <mode name='host-passthrough' supported='yes'>
 	//   <enum name='hostPassthroughMigratable'/>
@@ -536,7 +536,7 @@ type HypervisorStatus struct {
 	Cells []Cell `json:"cells,omitempty"`
 
 	// +kubebuilder:default:=0
-	// Represent the num of instances
+	// Represents the number of instances running on this hypervisor.
 	NumInstances int `json:"numInstances"`
 
 	// HypervisorID is the unique identifier of the hypervisor in OpenStack.

--- a/applyconfigurations/api/v1/aggregate.go
+++ b/applyconfigurations/api/v1/aggregate.go
@@ -4,9 +4,14 @@ package v1
 
 // AggregateApplyConfiguration represents a declarative configuration of the Aggregate type for use
 // with apply.
+//
+// Aggregate represents an OpenStack aggregate with its name and UUID.
 type AggregateApplyConfiguration struct {
-	Name     *string           `json:"name,omitempty"`
-	UUID     *string           `json:"uuid,omitempty"`
+	// Name is the name of the aggregate.
+	Name *string `json:"name,omitempty"`
+	// UUID is the unique identifier of the aggregate.
+	UUID *string `json:"uuid,omitempty"`
+	// Metadata is the metadata of the aggregate as key-value pairs.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 

--- a/applyconfigurations/api/v1/aggregategroup.go
+++ b/applyconfigurations/api/v1/aggregategroup.go
@@ -4,6 +4,9 @@ package v1
 
 // AggregateGroupApplyConfiguration represents a declarative configuration of the AggregateGroup type for use
 // with apply.
+//
+// AggregateGroup represents an administrative grouping, such as an
+// OpenStack host aggregate.
 type AggregateGroupApplyConfiguration struct {
 	Name     *string           `json:"name,omitempty"`
 	UUID     *string           `json:"uuid,omitempty"`

--- a/applyconfigurations/api/v1/capabilities.go
+++ b/applyconfigurations/api/v1/capabilities.go
@@ -8,10 +8,15 @@ import (
 
 // CapabilitiesApplyConfiguration represents a declarative configuration of the Capabilities type for use
 // with apply.
+//
+// Capabilities of the hypervisor as reported by libvirt.
 type CapabilitiesApplyConfiguration struct {
-	HostCpuArch *string            `json:"cpuArch,omitempty"`
-	HostMemory  *resource.Quantity `json:"memory,omitempty"`
-	HostCpus    *resource.Quantity `json:"cpus,omitempty"`
+	// The hosts CPU architecture (not the guests).
+	HostCpuArch *string `json:"cpuArch,omitempty"`
+	// Total host memory available as a sum of memory over all numa cells.
+	HostMemory *resource.Quantity `json:"memory,omitempty"`
+	// Total host cpus available as a sum of cpus over all numa cells.
+	HostCpus *resource.Quantity `json:"cpus,omitempty"`
 }
 
 // CapabilitiesApplyConfiguration constructs a declarative configuration of the Capabilities type for use with

--- a/applyconfigurations/api/v1/cell.go
+++ b/applyconfigurations/api/v1/cell.go
@@ -9,10 +9,28 @@ import (
 
 // CellApplyConfiguration represents a declarative configuration of the Cell type for use
 // with apply.
+//
+// Cell represents a NUMA cell on the hypervisor.
 type CellApplyConfiguration struct {
-	CellID            *uint64                                  `json:"cellID,omitempty"`
-	Allocation        map[apiv1.ResourceName]resource.Quantity `json:"allocation,omitempty"`
-	Capacity          map[apiv1.ResourceName]resource.Quantity `json:"capacity,omitempty"`
+	// Cell ID.
+	CellID *uint64 `json:"cellID,omitempty"`
+	// Auto-discovered resource allocation of all hosted VMs in this cell.
+	Allocation map[apiv1.ResourceName]resource.Quantity `json:"allocation,omitempty"`
+	// Auto-discovered capacity of this cell.
+	//
+	// Note that this capacity does not include the applied overcommit ratios,
+	// and represents the actual capacity of the cell. Use the effective capacity
+	// field to get the capacity considering the applied overcommit ratios.
+	Capacity map[apiv1.ResourceName]resource.Quantity `json:"capacity,omitempty"`
+	// Auto-discovered capacity of this cell, considering the
+	// applied overcommit ratios.
+	//
+	// In case no overcommit ratio is specified for a resource type, the default
+	// overcommit ratio of 1 should be applied, meaning the effective capacity
+	// is the same as the actual capacity.
+	//
+	// If the overcommit ratio results in a fractional effective capacity, the
+	// effective capacity is expected to be rounded down.
 	EffectiveCapacity map[apiv1.ResourceName]resource.Quantity `json:"effectiveCapacity,omitempty"`
 }
 

--- a/applyconfigurations/api/v1/domaincapabilities.go
+++ b/applyconfigurations/api/v1/domaincapabilities.go
@@ -4,11 +4,49 @@ package v1
 
 // DomainCapabilitiesApplyConfiguration represents a declarative configuration of the DomainCapabilities type for use
 // with apply.
+//
+// Domain capabilities of the hypervisor as reported by libvirt.
+// These details are relevant to check if a VM can be scheduled on the hypervisor.
 type DomainCapabilitiesApplyConfiguration struct {
-	Arch              *string  `json:"arch,omitempty"`
-	HypervisorType    *string  `json:"hypervisorType,omitempty"`
-	SupportedDevices  []string `json:"supportedDevices,omitempty"`
+	// The available domain cpu architecture.
+	Arch *string `json:"arch,omitempty"`
+	// The supported type of virtualization for domains, such as "ch".
+	HypervisorType *string `json:"hypervisorType,omitempty"`
+	// Supported devices for domains.
+	//
+	// The format of this list is the device type, and if specified, a specific
+	// model. For example, take the following xml domain device definition:
+	//
+	// <video supported='yes'>
+	// <enum name='modelType'>
+	// <value>nvidia</value>
+	// </enum>
+	// </video>
+	//
+	// The corresponding entries in this list would be "video" and "video/nvidia".
+	SupportedDevices []string `json:"supportedDevices,omitempty"`
+	// Supported cpu modes for domains.
+	//
+	// The format of this list is cpu mode, and if specified, a specific
+	// submode. For example, take the following xml domain cpu definition:
+	//
+	// <mode name='host-passthrough' supported='yes'>
+	// <enum name='hostPassthroughMigratable'/>
+	// </mode>
+	//
+	// The corresponding entries in this list would be "host-passthrough" and
+	// "host-passthrough/migratable".
 	SupportedCpuModes []string `json:"supportedCpuModes,omitempty"`
+	// Supported features for domains, such as "sev" or "sgx".
+	//
+	// This is a flat list of supported features, meaning the following xml:
+	//
+	// <features>
+	// <sev supported='no'/>
+	// <sgx supported='no'/>
+	// </features>
+	//
+	// Would correspond to the entries "sev" and "sgx" in this list.
 	SupportedFeatures []string `json:"supportedFeatures,omitempty"`
 }
 

--- a/applyconfigurations/api/v1/eviction.go
+++ b/applyconfigurations/api/v1/eviction.go
@@ -3,13 +3,18 @@
 package v1
 
 import (
+	apiv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
+	internal "github.com/cobaltcore-dev/openstack-hypervisor-operator/applyconfigurations/internal"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // EvictionApplyConfiguration represents a declarative configuration of the Eviction type for use
 // with apply.
+//
+// Eviction is the Schema for the evictions API
 type EvictionApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration    `json:",inline"`
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
@@ -19,14 +24,54 @@ type EvictionApplyConfiguration struct {
 
 // Eviction constructs a declarative configuration of the Eviction type for use with
 // apply.
-func Eviction(name, namespace string) *EvictionApplyConfiguration {
+func Eviction(name string) *EvictionApplyConfiguration {
 	b := &EvictionApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("Eviction")
 	b.WithAPIVersion("kvm.cloud.sap/v1")
 	return b
 }
+
+// ExtractEvictionFrom extracts the applied configuration owned by fieldManager from
+// eviction for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// eviction must be a unmodified Eviction API object that was retrieved from the Kubernetes API.
+// ExtractEvictionFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+func ExtractEvictionFrom(eviction *apiv1.Eviction, fieldManager string, subresource string) (*EvictionApplyConfiguration, error) {
+	b := &EvictionApplyConfiguration{}
+	err := managedfields.ExtractInto(eviction, internal.Parser().Type("com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Eviction"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(eviction.Name)
+
+	b.WithKind("Eviction")
+	b.WithAPIVersion("kvm.cloud.sap/v1")
+	return b, nil
+}
+
+// ExtractEviction extracts the applied configuration owned by fieldManager from
+// eviction. If no managedFields are found in eviction for fieldManager, a
+// EvictionApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// eviction must be a unmodified Eviction API object that was retrieved from the Kubernetes API.
+// ExtractEviction provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+func ExtractEviction(eviction *apiv1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
+	return ExtractEvictionFrom(eviction, fieldManager, "")
+}
+
+// ExtractEvictionStatus extracts the applied configuration owned by fieldManager from
+// eviction for the status subresource.
+func ExtractEvictionStatus(eviction *apiv1.Eviction, fieldManager string) (*EvictionApplyConfiguration, error) {
+	return ExtractEvictionFrom(eviction, fieldManager, "status")
+}
+
 func (b EvictionApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/applyconfigurations/api/v1/evictionspec.go
+++ b/applyconfigurations/api/v1/evictionspec.go
@@ -4,9 +4,13 @@ package v1
 
 // EvictionSpecApplyConfiguration represents a declarative configuration of the EvictionSpec type for use
 // with apply.
+//
+// EvictionSpec defines the desired state of Eviction
 type EvictionSpecApplyConfiguration struct {
+	// Name of hypervisor to evict
 	Hypervisor *string `json:"hypervisor,omitempty"`
-	Reason     *string `json:"reason,omitempty"`
+	// Reason for eviction, always required
+	Reason *string `json:"reason,omitempty"`
 }
 
 // EvictionSpecApplyConfiguration constructs a declarative configuration of the EvictionSpec type for use with

--- a/applyconfigurations/api/v1/evictionstatus.go
+++ b/applyconfigurations/api/v1/evictionstatus.go
@@ -8,11 +8,14 @@ import (
 
 // EvictionStatusApplyConfiguration represents a declarative configuration of the EvictionStatus type for use
 // with apply.
+//
+// EvictionStatus defines the observed state of Eviction
 type EvictionStatusApplyConfiguration struct {
-	HypervisorServiceId  *string                              `json:"hypervisorServiceId,omitempty"`
-	OutstandingRamMb     *int64                               `json:"outstandingRamMb,omitempty"`
-	OutstandingInstances []string                             `json:"outstandingInstances,omitempty"`
-	Conditions           []metav1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	HypervisorServiceId  *string  `json:"hypervisorServiceId,omitempty"`
+	OutstandingRamMb     *int64   `json:"outstandingRamMb,omitempty"`
+	OutstandingInstances []string `json:"outstandingInstances,omitempty"`
+	// Conditions is an array of current conditions
+	Conditions []metav1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 }
 
 // EvictionStatusApplyConfiguration constructs a declarative configuration of the EvictionStatus type for use with

--- a/applyconfigurations/api/v1/group.go
+++ b/applyconfigurations/api/v1/group.go
@@ -4,6 +4,13 @@ package v1
 
 // GroupApplyConfiguration represents a declarative configuration of the Group type for use
 // with apply.
+//
+// Group is a typed group membership entry for a hypervisor.
+//
+// This follows the field-presence union pattern (as used by
+// PodSpec.volumes in core Kubernetes): each entry populates exactly
+// one type-specific sub-field, and the populated field identifies
+// the group type.
 type GroupApplyConfiguration struct {
 	Trait     *TraitGroupApplyConfiguration     `json:"trait,omitempty"`
 	Aggregate *AggregateGroupApplyConfiguration `json:"aggregate,omitempty"`

--- a/applyconfigurations/api/v1/hypervisor.go
+++ b/applyconfigurations/api/v1/hypervisor.go
@@ -3,13 +3,18 @@
 package v1
 
 import (
+	apiv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
+	internal "github.com/cobaltcore-dev/openstack-hypervisor-operator/applyconfigurations/internal"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // HypervisorApplyConfiguration represents a declarative configuration of the Hypervisor type for use
 // with apply.
+//
+// Hypervisor is the Schema for the hypervisors API
 type HypervisorApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration    `json:",inline"`
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
@@ -19,14 +24,54 @@ type HypervisorApplyConfiguration struct {
 
 // Hypervisor constructs a declarative configuration of the Hypervisor type for use with
 // apply.
-func Hypervisor(name, namespace string) *HypervisorApplyConfiguration {
+func Hypervisor(name string) *HypervisorApplyConfiguration {
 	b := &HypervisorApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("Hypervisor")
 	b.WithAPIVersion("kvm.cloud.sap/v1")
 	return b
 }
+
+// ExtractHypervisorFrom extracts the applied configuration owned by fieldManager from
+// hypervisor for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// hypervisor must be a unmodified Hypervisor API object that was retrieved from the Kubernetes API.
+// ExtractHypervisorFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+func ExtractHypervisorFrom(hypervisor *apiv1.Hypervisor, fieldManager string, subresource string) (*HypervisorApplyConfiguration, error) {
+	b := &HypervisorApplyConfiguration{}
+	err := managedfields.ExtractInto(hypervisor, internal.Parser().Type("com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Hypervisor"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(hypervisor.Name)
+
+	b.WithKind("Hypervisor")
+	b.WithAPIVersion("kvm.cloud.sap/v1")
+	return b, nil
+}
+
+// ExtractHypervisor extracts the applied configuration owned by fieldManager from
+// hypervisor. If no managedFields are found in hypervisor for fieldManager, a
+// HypervisorApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// hypervisor must be a unmodified Hypervisor API object that was retrieved from the Kubernetes API.
+// ExtractHypervisor provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+func ExtractHypervisor(hypervisor *apiv1.Hypervisor, fieldManager string) (*HypervisorApplyConfiguration, error) {
+	return ExtractHypervisorFrom(hypervisor, fieldManager, "")
+}
+
+// ExtractHypervisorStatus extracts the applied configuration owned by fieldManager from
+// hypervisor for the status subresource.
+func ExtractHypervisorStatus(hypervisor *apiv1.Hypervisor, fieldManager string) (*HypervisorApplyConfiguration, error) {
+	return ExtractHypervisorFrom(hypervisor, fieldManager, "status")
+}
+
 func (b HypervisorApplyConfiguration) IsApplyConfiguration() {}
 
 // WithKind sets the Kind field in the declarative configuration to the given value

--- a/applyconfigurations/api/v1/hypervisorspec.go
+++ b/applyconfigurations/api/v1/hypervisorspec.go
@@ -47,10 +47,11 @@ type HypervisorSpecApplyConfiguration struct {
 	AllowedProjects []string `json:"allowedProjects,omitempty"`
 	// HighAvailability is used to enable the high availability handling of the hypervisor.
 	HighAvailability *bool `json:"highAvailability,omitempty"`
-	// Requires issuing a certificate from cert-manager for the hypervisor, to be used for
-	// secure communication with the libvirt API.
+	// CreateCertManagerCertificate requests that a certificate be issued from
+	// cert-manager for the hypervisor, to be used for secure communication
+	// with the libvirt API.
 	CreateCertManagerCertificate *bool `json:"createCertManagerCertificate,omitempty"`
-	// InstallCertificate is used to enable the installation of the certificates via kvm-node-agent.
+	// InstallCertificate enables installation of certificates via kvm-node-agent.
 	InstallCertificate *bool `json:"installCertificate,omitempty"`
 	// Maintenance indicates whether the hypervisor is in maintenance mode.
 	Maintenance *string `json:"maintenance,omitempty"`

--- a/applyconfigurations/api/v1/hypervisorspec.go
+++ b/applyconfigurations/api/v1/hypervisorspec.go
@@ -8,22 +8,68 @@ import (
 
 // HypervisorSpecApplyConfiguration represents a declarative configuration of the HypervisorSpec type for use
 // with apply.
+//
+// HypervisorSpec defines the desired state of Hypervisor
 type HypervisorSpecApplyConfiguration struct {
-	OperatingSystemVersion       *string                        `json:"version,omitempty"`
-	Reboot                       *bool                          `json:"reboot,omitempty"`
-	EvacuateOnReboot             *bool                          `json:"evacuateOnReboot,omitempty"`
-	LifecycleEnabled             *bool                          `json:"lifecycleEnabled,omitempty"`
-	SkipTests                    *bool                          `json:"skipTests,omitempty"`
-	CustomTraits                 []string                       `json:"customTraits,omitempty"`
-	Aggregates                   []string                       `json:"aggregates,omitempty"`
-	Groups                       []GroupApplyConfiguration      `json:"groups,omitempty"`
-	AllowedProjects              []string                       `json:"allowedProjects,omitempty"`
-	HighAvailability             *bool                          `json:"highAvailability,omitempty"`
-	CreateCertManagerCertificate *bool                          `json:"createCertManagerCertificate,omitempty"`
-	InstallCertificate           *bool                          `json:"installCertificate,omitempty"`
-	Maintenance                  *string                        `json:"maintenance,omitempty"`
-	MaintenanceReason            *string                        `json:"maintenanceReason,omitempty"`
-	Overcommit                   map[apiv1.ResourceName]float64 `json:"overcommit,omitempty"`
+	// OperatingSystemVersion represents the desired operating system version.
+	OperatingSystemVersion *string `json:"version,omitempty"`
+	// Reboot requests a reboot after successful installation of an upgrade.
+	Reboot *bool `json:"reboot,omitempty"`
+	// EvacuateOnReboot requests an evacuation of all instances before reboot.
+	EvacuateOnReboot *bool `json:"evacuateOnReboot,omitempty"`
+	// LifecycleEnabled enables the lifecycle management of the hypervisor via hypervisor-operator.
+	LifecycleEnabled *bool `json:"lifecycleEnabled,omitempty"`
+	// SkipTests skips the tests during the onboarding process.
+	SkipTests *bool `json:"skipTests,omitempty"`
+	// CustomTraits are used to apply custom traits to the hypervisor.
+	CustomTraits []string `json:"customTraits,omitempty"`
+	// Aggregates are used to apply aggregates to the hypervisor.
+	Aggregates []string `json:"aggregates,omitempty"`
+	// Groups defines typed group memberships for this hypervisor.
+	//
+	// Both traits and aggregates are forms of grouping: traits group
+	// hypervisors by capability, aggregates group them by administrative
+	// assignment. Each entry follows the field-presence union pattern
+	// (as used by PodSpec.volumes in core Kubernetes): exactly one
+	// type-specific sub-field must be populated per entry.
+	//
+	// The Cortex Placement shim and scheduler read group memberships
+	// directly from this field.
+	//
+	// Note: uniqueness of trait names and aggregate UUIDs is not enforced
+	// via CEL because the required O(n^2) comparison exceeds the
+	// Kubernetes CEL cost budget. Enforce uniqueness in the consuming
+	// controller or via a validating webhook if needed.
+	Groups []GroupApplyConfiguration `json:"groups,omitempty"`
+	// AllowedProjects defines which openstack projects are allowed to schedule
+	// instances on this hypervisor. The values of this list should be project
+	// uuids. If left empty, all projects are allowed.
+	AllowedProjects []string `json:"allowedProjects,omitempty"`
+	// HighAvailability is used to enable the high availability handling of the hypervisor.
+	HighAvailability *bool `json:"highAvailability,omitempty"`
+	// Requires issuing a certificate from cert-manager for the hypervisor, to be used for
+	// secure communication with the libvirt API.
+	CreateCertManagerCertificate *bool `json:"createCertManagerCertificate,omitempty"`
+	// InstallCertificate is used to enable the installation of the certificates via kvm-node-agent.
+	InstallCertificate *bool `json:"installCertificate,omitempty"`
+	// Maintenance indicates whether the hypervisor is in maintenance mode.
+	Maintenance *string `json:"maintenance,omitempty"`
+	// MaintenanceReason provides the reason for manual maintenance mode.
+	MaintenanceReason *string `json:"maintenanceReason,omitempty"`
+	// Overcommit specifies the desired overcommit ratio by resource type.
+	//
+	// If no overcommit is specified for a resource type, the default overcommit
+	// ratio of 1.0 should be applied, i.e. the effective capacity is the same
+	// as the actual capacity.
+	//
+	// If the overcommit ratio results in a fractional effective capacity,
+	// the effective capacity is expected to be rounded down. This allows
+	// gradually adjusting the hypervisor capacity.
+	//
+	// It is validated that all overcommit ratios are greater than or equal to
+	// 1.0, if specified. For this we don't need extra validating webhooks.
+	// See: https://kubernetes.io/blog/2022/09/23/crd-validation-rules-beta/#crd-transition-rules
+	Overcommit map[apiv1.ResourceName]float64 `json:"overcommit,omitempty"`
 }
 
 // HypervisorSpecApplyConfiguration constructs a declarative configuration of the HypervisorSpec type for use with

--- a/applyconfigurations/api/v1/hypervisorstatus.go
+++ b/applyconfigurations/api/v1/hypervisorstatus.go
@@ -10,27 +10,62 @@ import (
 
 // HypervisorStatusApplyConfiguration represents a declarative configuration of the HypervisorStatus type for use
 // with apply.
+//
+// HypervisorStatus defines the observed state of Hypervisor
 type HypervisorStatusApplyConfiguration struct {
-	LibVirtVersion     *string                                   `json:"libVirtVersion,omitempty"`
-	HypervisorVersion  *string                                   `json:"hypervisorVersion,omitempty"`
-	OperatingSystem    *OperatingSystemStatusApplyConfiguration  `json:"operatingSystem,omitempty"`
-	Update             *HyperVisorUpdateStatusApplyConfiguration `json:"updateStatus,omitempty"`
-	Instances          []InstanceApplyConfiguration              `json:"instances,omitempty"`
-	Capabilities       *CapabilitiesApplyConfiguration           `json:"capabilities,omitempty"`
-	DomainCapabilities *DomainCapabilitiesApplyConfiguration     `json:"domainCapabilities,omitempty"`
-	Allocation         map[apiv1.ResourceName]resource.Quantity  `json:"allocation,omitempty"`
-	Capacity           map[apiv1.ResourceName]resource.Quantity  `json:"capacity,omitempty"`
-	EffectiveCapacity  map[apiv1.ResourceName]resource.Quantity  `json:"effectiveCapacity,omitempty"`
-	Cells              []CellApplyConfiguration                  `json:"cells,omitempty"`
-	NumInstances       *int                                      `json:"numInstances,omitempty"`
-	HypervisorID       *string                                   `json:"hypervisorId,omitempty"`
-	ServiceID          *string                                   `json:"serviceId,omitempty"`
-	Traits             []string                                  `json:"traits,omitempty"`
-	Aggregates         []AggregateApplyConfiguration             `json:"aggregates,omitempty"`
-	InternalIP         *string                                   `json:"internalIp,omitempty"`
-	Evicted            *bool                                     `json:"evicted,omitempty"`
-	Conditions         []metav1.ConditionApplyConfiguration      `json:"conditions,omitempty"`
-	SpecHash           *string                                   `json:"specHash,omitempty"`
+	// Represents the LibVirt version.
+	LibVirtVersion *string `json:"libVirtVersion,omitempty"`
+	// Represents the Hypervisor version
+	HypervisorVersion *string `json:"hypervisorVersion,omitempty"`
+	// Represents the Operating System status.
+	OperatingSystem *OperatingSystemStatusApplyConfiguration `json:"operatingSystem,omitempty"`
+	// Represents the Hypervisor update status.
+	Update *HyperVisorUpdateStatusApplyConfiguration `json:"updateStatus,omitempty"`
+	// Represents the Hypervisor hosted Virtual Machines
+	Instances []InstanceApplyConfiguration `json:"instances,omitempty"`
+	// Auto-discovered capabilities as reported by libvirt.
+	Capabilities *CapabilitiesApplyConfiguration `json:"capabilities,omitempty"`
+	// Auto-discovered domain capabilities relevant to check if a VM
+	// can be scheduled on the hypervisor.
+	DomainCapabilities *DomainCapabilitiesApplyConfiguration `json:"domainCapabilities,omitempty"`
+	// Auto-discovered resource allocation of all hosted VMs.
+	Allocation map[apiv1.ResourceName]resource.Quantity `json:"allocation,omitempty"`
+	// Auto-discovered capacity of the hypervisor.
+	//
+	// Note that this capacity does not include the applied overcommit ratios,
+	// and represents the actual capacity of the hypervisor. Use the
+	// effective capacity field to get the capacity considering the applied
+	// overcommit ratios.
+	Capacity map[apiv1.ResourceName]resource.Quantity `json:"capacity,omitempty"`
+	// Auto-discovered capacity of the hypervisor, considering the
+	// applied overcommit ratios.
+	//
+	// In case no overcommit ratio is specified for a resource type, the default
+	// overcommit ratio of 1 should be applied, meaning the effective capacity
+	// is the same as the actual capacity.
+	//
+	// If the overcommit ratio results in a fractional effective capacity, the
+	// effective capacity is expected to be rounded down.
+	EffectiveCapacity map[apiv1.ResourceName]resource.Quantity `json:"effectiveCapacity,omitempty"`
+	// Auto-discovered cells on this hypervisor.
+	Cells []CellApplyConfiguration `json:"cells,omitempty"`
+	// Represents the number of instances running on this hypervisor.
+	NumInstances *int `json:"numInstances,omitempty"`
+	// HypervisorID is the unique identifier of the hypervisor in OpenStack.
+	HypervisorID *string `json:"hypervisorId,omitempty"`
+	// ServiceID is the unique identifier of the compute service in OpenStack.
+	ServiceID *string `json:"serviceId,omitempty"`
+	// Traits are the applied traits of the hypervisor.
+	Traits []string `json:"traits,omitempty"`
+	// Aggregates are the applied aggregates of the hypervisor with their names and UUIDs.
+	Aggregates []AggregateApplyConfiguration `json:"aggregates,omitempty"`
+	// InternalIP is the internal IP address of the hypervisor.
+	InternalIP *string `json:"internalIp,omitempty"`
+	// Evicted indicates whether the hypervisor is evicted. (no instances left with active maintenance mode)
+	Evicted *bool `json:"evicted,omitempty"`
+	// Represents the Hypervisor node conditions.
+	Conditions []metav1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	SpecHash   *string                              `json:"specHash,omitempty"`
 }
 
 // HypervisorStatusApplyConfiguration constructs a declarative configuration of the HypervisorStatus type for use with

--- a/applyconfigurations/api/v1/hypervisorupdatestatus.go
+++ b/applyconfigurations/api/v1/hypervisorupdatestatus.go
@@ -5,9 +5,12 @@ package v1
 // HyperVisorUpdateStatusApplyConfiguration represents a declarative configuration of the HyperVisorUpdateStatus type for use
 // with apply.
 type HyperVisorUpdateStatusApplyConfiguration struct {
-	InProgress *bool   `json:"inProgress,omitempty"`
-	Installed  *string `json:"installed,omitempty"`
-	Retry      *int    `json:"retry,omitempty"`
+	// Represents a running Operating System update.
+	InProgress *bool `json:"inProgress,omitempty"`
+	// Represents the Operating System installed update version.
+	Installed *string `json:"installed,omitempty"`
+	// Represents the number of retries.
+	Retry *int `json:"retry,omitempty"`
 }
 
 // HyperVisorUpdateStatusApplyConfiguration constructs a declarative configuration of the HyperVisorUpdateStatus type for use with

--- a/applyconfigurations/api/v1/instance.go
+++ b/applyconfigurations/api/v1/instance.go
@@ -5,9 +5,12 @@ package v1
 // InstanceApplyConfiguration represents a declarative configuration of the Instance type for use
 // with apply.
 type InstanceApplyConfiguration struct {
-	ID     *string `json:"id,omitempty"`
-	Name   *string `json:"name,omitempty"`
-	Active *bool   `json:"active,omitempty"`
+	// Represents the instance ID (uuidv4).
+	ID *string `json:"id,omitempty"`
+	// Represents the instance name.
+	Name *string `json:"name,omitempty"`
+	// Represents the instance state.
+	Active *bool `json:"active,omitempty"`
 }
 
 // InstanceApplyConfiguration constructs a declarative configuration of the Instance type for use with

--- a/applyconfigurations/api/v1/operatingsystemstatus.go
+++ b/applyconfigurations/api/v1/operatingsystemstatus.go
@@ -9,21 +9,36 @@ import (
 // OperatingSystemStatusApplyConfiguration represents a declarative configuration of the OperatingSystemStatus type for use
 // with apply.
 type OperatingSystemStatusApplyConfiguration struct {
-	Version             *string      `json:"version,omitempty"`
-	VariantID           *string      `json:"variantID,omitempty"`
-	PrettyVersion       *string      `json:"prettyVersion,omitempty"`
-	KernelName          *string      `json:"kernelName,omitempty"`
-	KernelRelease       *string      `json:"kernelRelease,omitempty"`
-	KernelVersion       *string      `json:"kernelVersion,omitempty"`
-	KernelCommandLine   *string      `json:"kernelCommandLine,omitempty"`
-	HardwareVendor      *string      `json:"hardwareVendor,omitempty"`
-	HardwareModel       *string      `json:"hardwareModel,omitempty"`
-	HardwareSerial      *string      `json:"hardwareSerial,omitempty"`
-	FirmwareVersion     *string      `json:"firmwareVersion,omitempty"`
-	FirmwareVendor      *string      `json:"firmwareVendor,omitempty"`
-	FirmwareDate        *metav1.Time `json:"firmwareDate,omitempty"`
-	GardenLinuxCommitID *string      `json:"gardenLinuxCommitID,omitempty"`
-	GardenLinuxFeatures []string     `json:"gardenLinuxFeatures,omitempty"`
+	// Represents the Operating System version.
+	Version *string `json:"version,omitempty"`
+	// Identifying a specific variant or edition of the operating system
+	VariantID *string `json:"variantID,omitempty"`
+	// PrettyVersion
+	PrettyVersion *string `json:"prettyVersion,omitempty"`
+	// KernelName
+	KernelName *string `json:"kernelName,omitempty"`
+	// KernelRelease
+	KernelRelease *string `json:"kernelRelease,omitempty"`
+	// KernelVersion
+	KernelVersion *string `json:"kernelVersion,omitempty"`
+	// KernelCommandLine contains the raw kernel boot parameters from /proc/cmdline.
+	KernelCommandLine *string `json:"kernelCommandLine,omitempty"`
+	// HardwareVendor
+	HardwareVendor *string `json:"hardwareVendor,omitempty"`
+	// HardwareModel
+	HardwareModel *string `json:"hardwareModel,omitempty"`
+	// HardwareSerial
+	HardwareSerial *string `json:"hardwareSerial,omitempty"`
+	// FirmwareVersion
+	FirmwareVersion *string `json:"firmwareVersion,omitempty"`
+	// FirmwareVendor
+	FirmwareVendor *string `json:"firmwareVendor,omitempty"`
+	// FirmwareDate
+	FirmwareDate *metav1.Time `json:"firmwareDate,omitempty"`
+	// Represents the Garden Linux build commit id
+	GardenLinuxCommitID *string `json:"gardenLinuxCommitID,omitempty"`
+	// Represents the Garden Linux Feature Set
+	GardenLinuxFeatures []string `json:"gardenLinuxFeatures,omitempty"`
 }
 
 // OperatingSystemStatusApplyConfiguration constructs a declarative configuration of the OperatingSystemStatus type for use with

--- a/applyconfigurations/api/v1/traitgroup.go
+++ b/applyconfigurations/api/v1/traitgroup.go
@@ -4,6 +4,9 @@ package v1
 
 // TraitGroupApplyConfiguration represents a declarative configuration of the TraitGroup type for use
 // with apply.
+//
+// TraitGroup represents a capability trait, such as an OpenStack
+// Placement trait (e.g. HW_CPU_X86_AVX2, COMPUTE_STATUS_DISABLED).
 type TraitGroupApplyConfiguration struct {
 	Name *string `json:"name,omitempty"`
 }

--- a/applyconfigurations/internal/internal.go
+++ b/applyconfigurations/internal/internal.go
@@ -23,6 +23,583 @@ func Parser() *typed.Parser {
 var parserOnce sync.Once
 var parser *typed.Parser
 var schemaYAML = typed.YAMLObject(`types:
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Aggregate
+  map:
+    fields:
+    - name: metadata
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: uuid
+      type:
+        scalar: string
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.AggregateGroup
+  map:
+    fields:
+    - name: metadata
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: uuid
+      type:
+        scalar: string
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Capabilities
+  map:
+    fields:
+    - name: cpuArch
+      type:
+        scalar: string
+      default: unknown
+    - name: cpus
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: memory
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Cell
+  map:
+    fields:
+    - name: allocation
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: capacity
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: cellID
+      type:
+        scalar: numeric
+    - name: effectiveCapacity
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.DomainCapabilities
+  map:
+    fields:
+    - name: arch
+      type:
+        scalar: string
+      default: unknown
+    - name: hypervisorType
+      type:
+        scalar: string
+      default: unknown
+    - name: supportedCpuModes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+      default: []
+    - name: supportedDevices
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+      default: []
+    - name: supportedFeatures
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+      default: []
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Eviction
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.EvictionSpec
+    - name: status
+      type:
+        namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.EvictionStatus
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.EvictionSpec
+  map:
+    fields:
+    - name: hypervisor
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.EvictionStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Condition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: hypervisorServiceId
+      type:
+        scalar: string
+    - name: outstandingInstances
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: outstandingRamMb
+      type:
+        scalar: numeric
+      default: 0
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Group
+  map:
+    fields:
+    - name: aggregate
+      type:
+        namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.AggregateGroup
+    - name: trait
+      type:
+        namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.TraitGroup
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.HyperVisorUpdateStatus
+  map:
+    fields:
+    - name: inProgress
+      type:
+        scalar: boolean
+      default: false
+    - name: installed
+      type:
+        scalar: string
+      default: unknown
+    - name: retry
+      type:
+        scalar: numeric
+      default: 3
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Hypervisor
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.HypervisorSpec
+    - name: status
+      type:
+        namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.HypervisorStatus
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.HypervisorSpec
+  map:
+    fields:
+    - name: aggregates
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+      default: []
+    - name: allowedProjects
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+      default: []
+    - name: createCertManagerCertificate
+      type:
+        scalar: boolean
+      default: false
+    - name: customTraits
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+      default: []
+    - name: evacuateOnReboot
+      type:
+        scalar: boolean
+      default: true
+    - name: groups
+      type:
+        list:
+          elementType:
+            namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Group
+          elementRelationship: atomic
+    - name: highAvailability
+      type:
+        scalar: boolean
+      default: true
+    - name: installCertificate
+      type:
+        scalar: boolean
+      default: true
+    - name: lifecycleEnabled
+      type:
+        scalar: boolean
+      default: true
+    - name: maintenance
+      type:
+        scalar: string
+    - name: maintenanceReason
+      type:
+        scalar: string
+    - name: overcommit
+      type:
+        map:
+          elementType:
+            scalar: numeric
+    - name: reboot
+      type:
+        scalar: boolean
+      default: false
+    - name: skipTests
+      type:
+        scalar: boolean
+      default: false
+    - name: version
+      type:
+        scalar: string
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.HypervisorStatus
+  map:
+    fields:
+    - name: aggregates
+      type:
+        list:
+          elementType:
+            namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Aggregate
+          elementRelationship: atomic
+    - name: allocation
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: capabilities
+      type:
+        namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Capabilities
+    - name: capacity
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: cells
+      type:
+        list:
+          elementType:
+            namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Cell
+          elementRelationship: atomic
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Condition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: domainCapabilities
+      type:
+        namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.DomainCapabilities
+    - name: effectiveCapacity
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: evicted
+      type:
+        scalar: boolean
+    - name: hypervisorId
+      type:
+        scalar: string
+    - name: hypervisorVersion
+      type:
+        scalar: string
+      default: unknown
+    - name: instances
+      type:
+        list:
+          elementType:
+            namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Instance
+          elementRelationship: atomic
+    - name: internalIp
+      type:
+        scalar: string
+    - name: libVirtVersion
+      type:
+        scalar: string
+      default: unknown
+    - name: numInstances
+      type:
+        scalar: numeric
+      default: 0
+    - name: operatingSystem
+      type:
+        namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.OperatingSystemStatus
+    - name: serviceId
+      type:
+        scalar: string
+    - name: specHash
+      type:
+        scalar: string
+    - name: traits
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: updateStatus
+      type:
+        namedType: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.HyperVisorUpdateStatus
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.Instance
+  map:
+    fields:
+    - name: active
+      type:
+        scalar: boolean
+    - name: id
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.OperatingSystemStatus
+  map:
+    fields:
+    - name: firmwareDate
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: firmwareVendor
+      type:
+        scalar: string
+    - name: firmwareVersion
+      type:
+        scalar: string
+    - name: gardenLinuxCommitID
+      type:
+        scalar: string
+    - name: gardenLinuxFeatures
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: hardwareModel
+      type:
+        scalar: string
+    - name: hardwareSerial
+      type:
+        scalar: string
+    - name: hardwareVendor
+      type:
+        scalar: string
+    - name: kernelCommandLine
+      type:
+        scalar: string
+    - name: kernelName
+      type:
+        scalar: string
+    - name: kernelRelease
+      type:
+        scalar: string
+    - name: kernelVersion
+      type:
+        scalar: string
+    - name: prettyVersion
+      type:
+        scalar: string
+    - name: variantID
+      type:
+        scalar: string
+    - name: version
+      type:
+        scalar: string
+- name: com.github.cobaltcore-dev.openstack-hypervisor-operator.api.v1.TraitGroup
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.api.resource.Quantity
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Condition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ConditionStatus
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ConditionStatus
+  scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1
+  map:
+    elementType:
+      scalar: untyped
+      list:
+        elementType:
+          namedType: __untyped_atomic_
+        elementRelationship: atomic
+      map:
+        elementType:
+          namedType: __untyped_deduced_
+        elementRelationship: separable
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: fieldsType
+      type:
+        scalar: string
+    - name: fieldsV1
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1
+    - name: manager
+      type:
+        scalar: string
+    - name: operation
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsOperationType
+    - name: subresource
+      type:
+        scalar: string
+    - name: time
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsOperationType
+  scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+  map:
+    fields:
+    - name: annotations
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: creationTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: deletionGracePeriodSeconds
+      type:
+        scalar: numeric
+    - name: deletionTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: finalizers
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: generateName
+      type:
+        scalar: string
+    - name: generation
+      type:
+        scalar: numeric
+    - name: labels
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: managedFields
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry
+          elementRelationship: atomic
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: ownerReferences
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference
+          elementRelationship: associative
+          keys:
+          - uid
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: selfLink
+      type:
+        scalar: string
+    - name: uid
+      type:
+        namedType: io.k8s.apimachinery.pkg.types.UID
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: blockOwnerDeletion
+      type:
+        scalar: boolean
+    - name: controller
+      type:
+        scalar: boolean
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: uid
+      type:
+        namedType: io.k8s.apimachinery.pkg.types.UID
+    elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+  scalar: untyped
+- name: io.k8s.apimachinery.pkg.types.UID
+  scalar: string
 - name: __untyped_atomic_
   scalar: untyped
   list:

--- a/charts/openstack-hypervisor-operator/crds/kvm.cloud.sap_evictions.yaml
+++ b/charts/openstack-hypervisor-operator/crds/kvm.cloud.sap_evictions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: evictions.kvm.cloud.sap
 spec:
   group: kvm.cloud.sap

--- a/charts/openstack-hypervisor-operator/crds/kvm.cloud.sap_hypervisors.yaml
+++ b/charts/openstack-hypervisor-operator/crds/kvm.cloud.sap_hypervisors.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: hypervisors.kvm.cloud.sap
 spec:
   group: kvm.cloud.sap
@@ -122,7 +122,7 @@ spec:
               createCertManagerCertificate:
                 default: false
                 description: |-
-                  Require to issue a certificate from cert-manager for the hypervisor, to be used for
+                  Requires issuing a certificate from cert-manager for the hypervisor, to be used for
                   secure communication with the libvirt API.
                 type: boolean
               customTraits:
@@ -133,7 +133,7 @@ spec:
                 type: array
               evacuateOnReboot:
                 default: true
-                description: EvacuateOnReboot request an evacuation of all instances
+                description: EvacuateOnReboot requests an evacuation of all instances
                   before reboot.
                 type: boolean
               groups:
@@ -205,7 +205,7 @@ spec:
                 type: boolean
               installCertificate:
                 default: true
-                description: InstallCertificate is used to enable the installations
+                description: InstallCertificate is used to enable the installation
                   of the certificates via kvm-node-agent.
                 type: boolean
               lifecycleEnabled:
@@ -250,7 +250,7 @@ spec:
                   rule: self.all(k, self[k] >= 1.0)
               reboot:
                 default: false
-                description: Reboot request an reboot after successful installation
+                description: Reboot requests a reboot after successful installation
                   of an upgrade.
                 type: boolean
               skipTests:
@@ -491,7 +491,7 @@ spec:
                       Supported cpu modes for domains.
 
                       The format of this list is cpu mode, and if specified, a specific
-                      submode. For example, the take the following xml domain cpu definition:
+                      submode. For example, take the following xml domain cpu definition:
 
                       <mode name='host-passthrough' supported='yes'>
                         <enum name='hostPassthroughMigratable'/>
@@ -508,7 +508,7 @@ spec:
                       Supported devices for domains.
 
                       The format of this list is the device type, and if specified, a specific
-                      model. For example, the take the following xml domain device definition:
+                      model. For example, take the following xml domain device definition:
 
                       <video supported='yes'>
                         <enum name='modelType'>
@@ -595,7 +595,7 @@ spec:
                 type: string
               numInstances:
                 default: 0
-                description: Represent the num of instances
+                description: Represents the number of instances running on this hypervisor.
                 type: integer
               operatingSystem:
                 description: Represents the Operating System status.

--- a/charts/openstack-hypervisor-operator/crds/kvm.cloud.sap_hypervisors.yaml
+++ b/charts/openstack-hypervisor-operator/crds/kvm.cloud.sap_hypervisors.yaml
@@ -122,8 +122,9 @@ spec:
               createCertManagerCertificate:
                 default: false
                 description: |-
-                  Requires issuing a certificate from cert-manager for the hypervisor, to be used for
-                  secure communication with the libvirt API.
+                  CreateCertManagerCertificate requests that a certificate be issued from
+                  cert-manager for the hypervisor, to be used for secure communication
+                  with the libvirt API.
                 type: boolean
               customTraits:
                 default: []
@@ -205,8 +206,8 @@ spec:
                 type: boolean
               installCertificate:
                 default: true
-                description: InstallCertificate is used to enable the installation
-                  of the certificates via kvm-node-agent.
+                description: InstallCertificate enables installation of certificates
+                  via kvm-node-agent.
                 type: boolean
               lifecycleEnabled:
                 default: true


### PR DESCRIPTION
CI installs `controller-gen@latest` which is now v0.21.0. The new version correctly omits the namespace parameter from apply configuration constructors for cluster-scoped resources (Hypervisor, Eviction).

Without this regeneration, CI's `generate` step produces a 1-arg `Eviction()` / `Hypervisor()` signature while the committed code has the stale 2-arg version from v0.19.0. This causes build failures on any branch that calls these constructors (e.g. `ssa`, `rework-onboarding`).

This PR only contains regenerated output — no hand-written code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extracting applied configuration from existing hypervisor and eviction resources.
  * Expanded declarative configuration to include aggregate metadata and additional domain capability features.

* **Documentation**
  * Improved API and CRD descriptions for hypervisor, eviction, instance, capacity, and operating system fields.
  * Clarified several resource examples and status descriptions for easier understanding.

* **Chores**
  * Regenerated resource schemas and CRDs to align with the latest generation tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->