### PR TITLE
Migrate OnboardingController to SSA status updates

### DIFF
--- a/internal/controller/onboarding_controller.go
+++ b/internal/controller/onboarding_controller.go
@@ -26,11 +26,11 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	k8sacmetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,6 +45,7 @@ import (
 	"github.com/gophercloud/utils/v2/openstack/clientconfig"
 
 	kvmv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/api/v1"
+	apiv1 "github.com/cobaltcore-dev/openstack-hypervisor-operator/applyconfigurations/api/v1"
 	"github.com/cobaltcore-dev/openstack-hypervisor-operator/internal/openstack"
 	"github.com/cobaltcore-dev/openstack-hypervisor-operator/internal/utils"
 )
@@ -95,110 +96,120 @@ func (r *OnboardingController) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	computeHost := hv.Name
 
+	// Build the status apply config upfront; sub-functions mutate it.
+	// HypervisorID and ServiceID are always retained so they are never pruned.
+	statusCfg := apiv1.HypervisorStatus().
+		WithHypervisorID(hv.Status.HypervisorID).
+		WithServiceID(hv.Status.ServiceID)
+	// Seed the Onboarding condition this controller owns so it is not pruned.
+	if c := meta.FindStatusCondition(hv.Status.Conditions, kvmv1.ConditionTypeOnboarding); c != nil {
+		statusCfg.WithConditions(utils.ConditionFromStatus(*c))
+	}
+
+	apply := func() error {
+		return r.Status().Apply(ctx,
+			apiv1.Hypervisor(hv.Name).WithStatus(statusCfg),
+			k8sclient.ForceOwnership, k8sclient.FieldOwner(OnboardingControllerName))
+	}
+
 	// check if lifecycle management is enabled
 	if !hv.Spec.LifecycleEnabled {
-		return ctrl.Result{}, r.abortOnboarding(ctx, hv, computeHost, "Aborted due to LifecycleEnabled being false")
+		return ctrl.Result{}, r.abortOnboarding(ctx, hv, computeHost, "Aborted due to LifecycleEnabled being false", statusCfg, apply)
 	}
 
 	// check if hv is terminating
 	if hv.Spec.Maintenance == kvmv1.MaintenanceTermination {
-		return ctrl.Result{}, r.abortOnboarding(ctx, hv, computeHost, "Aborted due to MaintenanceTermination")
+		return ctrl.Result{}, r.abortOnboarding(ctx, hv, computeHost, "Aborted due to MaintenanceTermination", statusCfg, apply)
 	}
 
 	// We bail here out, because the openstack api is not the best to poll
 	if hv.Status.HypervisorID == "" || hv.Status.ServiceID == "" {
-		if err := r.ensureNovaProperties(ctx, hv); err != nil {
+		hypervisorID, serviceID, err := r.lookupNovaProperties(ctx, hv)
+		if err != nil {
 			if errors.Is(err, errRequeue) {
 				return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 			}
 			return ctrl.Result{}, err
 		}
+		statusCfg.WithHypervisorID(hypervisorID).WithServiceID(serviceID)
+		utils.SetApplyConfigurationStatusCondition(&statusCfg.Conditions,
+			*k8sacmetav1.Condition().
+				WithType(kvmv1.ConditionTypeOnboarding).
+				WithStatus(metav1.ConditionTrue).
+				WithReason(kvmv1.ConditionReasonInitial).
+				WithMessage("Initial onboarding"))
+		return ctrl.Result{}, apply()
 	}
 
 	// check condition reason
 	status := meta.FindStatusCondition(hv.Status.Conditions, kvmv1.ConditionTypeOnboarding)
 	if status == nil {
-		condition := metav1.Condition{
-			Type:    kvmv1.ConditionTypeOnboarding,
-			Status:  metav1.ConditionTrue,
-			Reason:  kvmv1.ConditionReasonInitial,
-			Message: "Initial onboarding",
-		}
-		return ctrl.Result{}, utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-			meta.SetStatusCondition(&h.Status.Conditions, condition)
-		})
+		// IDs are set but no condition yet — treat as the initial phase.
+		utils.SetApplyConfigurationStatusCondition(&statusCfg.Conditions,
+			*k8sacmetav1.Condition().
+				WithType(kvmv1.ConditionTypeOnboarding).
+				WithStatus(metav1.ConditionTrue).
+				WithReason(kvmv1.ConditionReasonInitial).
+				WithMessage("Initial onboarding"))
+		return ctrl.Result{}, apply()
 	}
-
 	switch status.Reason {
 	case kvmv1.ConditionReasonInitial:
-		return ctrl.Result{}, r.initialOnboarding(ctx, hv)
+		return ctrl.Result{}, r.initialOnboarding(ctx, hv, statusCfg, apply)
 	case kvmv1.ConditionReasonTesting:
 		if hv.Spec.SkipTests {
-			return r.completeOnboarding(ctx, computeHost, hv)
+			return r.completeOnboarding(ctx, computeHost, hv, statusCfg, apply)
 		} else {
-			return r.smokeTest(ctx, hv, computeHost)
+			return r.smokeTest(ctx, hv, computeHost, statusCfg, apply)
 		}
 	case kvmv1.ConditionReasonHandover:
-		return r.completeOnboarding(ctx, computeHost, hv)
+		return r.completeOnboarding(ctx, computeHost, hv, statusCfg, apply)
 	default:
 		// Nothing to be done
 		return ctrl.Result{}, nil
 	}
 }
 
-func (r *OnboardingController) abortOnboarding(ctx context.Context, hv *kvmv1.Hypervisor, computeHost, message string) error {
+func (r *OnboardingController) abortOnboarding(ctx context.Context, hv *kvmv1.Hypervisor, computeHost, message string, statusCfg *apiv1.HypervisorStatusApplyConfiguration, apply func() error) error {
 	status := meta.FindStatusCondition(hv.Status.Conditions, kvmv1.ConditionTypeOnboarding)
 	// Never onboarded
 	if status == nil {
 		return nil
 	}
 
-	base := hv.DeepCopy()
-
-	meta.SetStatusCondition(&hv.Status.Conditions, metav1.Condition{
-		Type:    kvmv1.ConditionTypeOnboarding,
-		Status:  metav1.ConditionFalse,
-		Reason:  kvmv1.ConditionReasonAborted,
-		Message: message,
-	})
-
-	if equality.Semantic.DeepEqual(hv, base) {
-		// Already aborted
+	// Already aborted with the same message — nothing to do
+	if status.Status == metav1.ConditionFalse &&
+		status.Reason == kvmv1.ConditionReasonAborted &&
+		status.Message == message {
 		return nil
 	}
 
-	condition := *meta.FindStatusCondition(hv.Status.Conditions, kvmv1.ConditionTypeOnboarding)
 	if err := r.deleteTestServers(ctx, computeHost); err != nil {
-		condition = metav1.Condition{
-			Type:    kvmv1.ConditionTypeOnboarding,
-			Status:  metav1.ConditionTrue, // No cleanup, so we are still "onboarding"
-			Reason:  kvmv1.ConditionReasonAborted,
-			Message: err.Error(),
-		}
-
-		meta.SetStatusCondition(&hv.Status.Conditions, condition)
-		if equality.Semantic.DeepEqual(hv, base) {
-			return err
-		}
-
-		return errors.Join(err, utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-			meta.SetStatusCondition(&h.Status.Conditions, condition)
-		}))
+		utils.SetApplyConfigurationStatusCondition(&statusCfg.Conditions,
+			*k8sacmetav1.Condition().
+				WithType(kvmv1.ConditionTypeOnboarding).
+				WithStatus(metav1.ConditionTrue). // No cleanup, so we are still "onboarding"
+				WithReason(kvmv1.ConditionReasonAborted).
+				WithMessage(err.Error()))
+		return errors.Join(err, apply())
 	}
 
-	return utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-		meta.SetStatusCondition(&h.Status.Conditions, condition)
-	})
+	utils.SetApplyConfigurationStatusCondition(&statusCfg.Conditions,
+		*k8sacmetav1.Condition().
+			WithType(kvmv1.ConditionTypeOnboarding).
+			WithStatus(metav1.ConditionFalse).
+			WithReason(kvmv1.ConditionReasonAborted).
+			WithMessage(message))
+	return apply()
 }
 
-func (r *OnboardingController) initialOnboarding(ctx context.Context, hv *kvmv1.Hypervisor) error {
+func (r *OnboardingController) initialOnboarding(ctx context.Context, hv *kvmv1.Hypervisor, statusCfg *apiv1.HypervisorStatusApplyConfiguration, apply func() error) error {
 	zone, found := hv.Labels[corev1.LabelTopologyZone]
 	if !found || zone == "" {
 		return fmt.Errorf("cannot find availability-zone label %v on node", corev1.LabelTopologyZone)
 	}
 
 	// Wait for aggregates controller to apply the desired state (zone and test aggregate)
-	// Extract aggregate names for comparison
 	currentAggregateNames := make([]string, len(hv.Status.Aggregates))
 	for i, agg := range hv.Status.Aggregates {
 		currentAggregateNames[i] = agg.Name
@@ -220,23 +231,31 @@ func (r *OnboardingController) initialOnboarding(ctx context.Context, hv *kvmv1.
 		return result.Err
 	}
 
-	condition := metav1.Condition{
-		Type:    kvmv1.ConditionTypeOnboarding,
-		Status:  metav1.ConditionTrue,
-		Reason:  kvmv1.ConditionReasonTesting,
-		Message: "Running onboarding tests",
-	}
-	return utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-		meta.SetStatusCondition(&h.Status.Conditions, condition)
-	})
+	utils.SetApplyConfigurationStatusCondition(&statusCfg.Conditions,
+		*k8sacmetav1.Condition().
+			WithType(kvmv1.ConditionTypeOnboarding).
+			WithStatus(metav1.ConditionTrue).
+			WithReason(kvmv1.ConditionReasonTesting).
+			WithMessage("Running onboarding tests"))
+	return apply()
 }
 
-func (r *OnboardingController) smokeTest(ctx context.Context, hv *kvmv1.Hypervisor, host string) (ctrl.Result, error) {
+func (r *OnboardingController) smokeTest(ctx context.Context, hv *kvmv1.Hypervisor, host string, statusCfg *apiv1.HypervisorStatusApplyConfiguration, apply func() error) (ctrl.Result, error) {
 	log := logger.FromContext(ctx)
 	zone := hv.Labels[corev1.LabelTopologyZone]
 	server, err := r.createOrGetTestServer(ctx, zone, host, hv.UID)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to create or get test instance: %w", err)
+	}
+
+	setTestingCondition := func(message string) error {
+		utils.SetApplyConfigurationStatusCondition(&statusCfg.Conditions,
+			*k8sacmetav1.Condition().
+				WithType(kvmv1.ConditionTypeOnboarding).
+				WithStatus(metav1.ConditionTrue).
+				WithReason(kvmv1.ConditionReasonTesting).
+				WithMessage(message))
+		return apply()
 	}
 
 	switch server.Status {
@@ -245,21 +264,12 @@ func (r *OnboardingController) smokeTest(ctx context.Context, hv *kvmv1.Hypervis
 		id := server.ID
 		server, err = servers.Get(ctx, r.testComputeClient, id).Extract()
 		if err != nil {
-			// should not happened
 			log.Error(err, "failed to get test instance, instance vanished", "id", id)
 			return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 		}
 
 		// Set condition back to testing
-		condition := metav1.Condition{
-			Type:    kvmv1.ConditionTypeOnboarding,
-			Status:  metav1.ConditionTrue,
-			Reason:  kvmv1.ConditionReasonTesting,
-			Message: "Server ended up in error state: " + server.Fault.Message,
-		}
-		if err = utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-			meta.SetStatusCondition(&h.Status.Conditions, condition)
-		}); err != nil {
+		if err = setTestingCondition("Server ended up in error state: " + server.Fault.Message); err != nil {
 			return ctrl.Result{}, err
 		}
 
@@ -268,38 +278,23 @@ func (r *OnboardingController) smokeTest(ctx context.Context, hv *kvmv1.Hypervis
 			log.Error(err, "failed to delete test instance", "id", id)
 		}
 
-		return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
+		return ctrl.Result{RequeueAfter: defaultWaitTime}, nil
+
 	case "ACTIVE":
 		consoleOutput, err := servers.
 			ShowConsoleOutput(ctx, r.testComputeClient, server.ID, servers.ShowConsoleOutputOpts{Length: 11}).
 			Extract()
 		if err != nil {
-			condition := metav1.Condition{
-				Type:    kvmv1.ConditionTypeOnboarding,
-				Status:  metav1.ConditionTrue,
-				Reason:  kvmv1.ConditionReasonTesting,
-				Message: fmt.Sprintf("could not get console output %v", err),
-			}
-			if err := utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-				meta.SetStatusCondition(&h.Status.Conditions, condition)
-			}); err != nil {
-				return ctrl.Result{}, err
+			if err2 := setTestingCondition(fmt.Sprintf("could not get console output %v", err)); err2 != nil {
+				return ctrl.Result{}, err2
 			}
 			return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 		}
 
 		if !strings.Contains(consoleOutput, server.Name) {
 			if !server.LaunchedAt.IsZero() && r.Clock.Now().After(server.LaunchedAt.Add(smokeTestTimeout)) {
-				condition := metav1.Condition{
-					Type:    kvmv1.ConditionTypeOnboarding,
-					Status:  metav1.ConditionTrue,
-					Reason:  kvmv1.ConditionReasonTesting,
-					Message: fmt.Sprintf("timeout waiting for console output since %v", server.LaunchedAt),
-				}
-				if err := utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-					meta.SetStatusCondition(&h.Status.Conditions, condition)
-				}); err != nil {
-					return ctrl.Result{}, err
+				if err2 := setTestingCondition(fmt.Sprintf("timeout waiting for console output since %v", server.LaunchedAt)); err2 != nil {
+					return ctrl.Result{}, err2
 				}
 				if err = servers.Delete(ctx, r.testComputeClient, server.ID).ExtractErr(); err != nil {
 					if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
@@ -311,28 +306,20 @@ func (r *OnboardingController) smokeTest(ctx context.Context, hv *kvmv1.Hypervis
 		}
 
 		if err = servers.Delete(ctx, r.testComputeClient, server.ID).ExtractErr(); err != nil {
-			condition := metav1.Condition{
-				Type:    kvmv1.ConditionTypeOnboarding,
-				Status:  metav1.ConditionTrue,
-				Reason:  kvmv1.ConditionReasonTesting,
-				Message: fmt.Sprintf("failed to terminate instance %v", err),
-			}
-			if err := utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-				meta.SetStatusCondition(&h.Status.Conditions, condition)
-			}); err != nil {
-				return ctrl.Result{}, err
+			if err2 := setTestingCondition(fmt.Sprintf("failed to terminate instance %v", err)); err2 != nil {
+				return ctrl.Result{}, err2
 			}
 			return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 		}
 
-		return r.completeOnboarding(ctx, host, hv)
+		return r.completeOnboarding(ctx, host, hv, statusCfg, apply)
+
 	default:
 		return ctrl.Result{RequeueAfter: r.getRequeueInterval()}, nil
 	}
 }
 
-func (r *OnboardingController) completeOnboarding(ctx context.Context, host string, hv *kvmv1.Hypervisor) (ctrl.Result, error) {
-	// Check if we're in the RemovingTestAggregate phase
+func (r *OnboardingController) completeOnboarding(ctx context.Context, host string, hv *kvmv1.Hypervisor, statusCfg *apiv1.HypervisorStatusApplyConfiguration, apply func() error) (ctrl.Result, error) {
 	onboardingCondition := meta.FindStatusCondition(hv.Status.Conditions, kvmv1.ConditionTypeOnboarding)
 	if onboardingCondition != nil && onboardingCondition.Reason == kvmv1.ConditionReasonHandover {
 		// We're waiting for aggregates and traits controllers to sync
@@ -348,44 +335,35 @@ func (r *OnboardingController) completeOnboarding(ctx context.Context, host stri
 			return ctrl.Result{}, nil
 		}
 
-		condition := metav1.Condition{
-			Type:    kvmv1.ConditionTypeOnboarding,
-			Status:  metav1.ConditionFalse,
-			Reason:  kvmv1.ConditionReasonSucceeded,
-			Message: "Onboarding completed",
-		}
-
-		return ctrl.Result{}, utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-			meta.SetStatusCondition(&h.Status.Conditions, condition)
-		})
+		utils.SetApplyConfigurationStatusCondition(&statusCfg.Conditions,
+			*k8sacmetav1.Condition().
+				WithType(kvmv1.ConditionTypeOnboarding).
+				WithStatus(metav1.ConditionFalse).
+				WithReason(kvmv1.ConditionReasonSucceeded).
+				WithMessage("Onboarding completed"))
+		return ctrl.Result{}, apply()
 	}
 
 	// First time in completeOnboarding - clean up and prepare for aggregate sync
-	err := r.deleteTestServers(ctx, host)
-	if err != nil {
-		condition := metav1.Condition{
-			Type:    kvmv1.ConditionTypeOnboarding,
-			Status:  metav1.ConditionTrue, // No cleanup, so we are still "onboarding"
-			Reason:  kvmv1.ConditionReasonAborted,
-			Message: err.Error(),
-		}
-		return ctrl.Result{}, errors.Join(err, utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-			meta.SetStatusCondition(&h.Status.Conditions, condition)
-		}))
+	if err := r.deleteTestServers(ctx, host); err != nil {
+		utils.SetApplyConfigurationStatusCondition(&statusCfg.Conditions,
+			*k8sacmetav1.Condition().
+				WithType(kvmv1.ConditionTypeOnboarding).
+				WithStatus(metav1.ConditionTrue). // No cleanup, so we are still "onboarding"
+				WithReason(kvmv1.ConditionReasonAborted).
+				WithMessage(err.Error()))
+		return ctrl.Result{}, errors.Join(err, apply())
 	}
 
 	// Mark onboarding as almost complete, triggers other controllers to do their part
-	condition := metav1.Condition{
-		Type:    kvmv1.ConditionTypeOnboarding,
-		Status:  metav1.ConditionTrue,
-		Reason:  kvmv1.ConditionReasonHandover,
-		Message: "Waiting for other controllers to take over",
-	}
-
 	// Patch status to signal aggregates controller
-	return ctrl.Result{}, utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-		meta.SetStatusCondition(&h.Status.Conditions, condition)
-	})
+	utils.SetApplyConfigurationStatusCondition(&statusCfg.Conditions,
+		*k8sacmetav1.Condition().
+			WithType(kvmv1.ConditionTypeOnboarding).
+			WithStatus(metav1.ConditionTrue).
+			WithReason(kvmv1.ConditionReasonHandover).
+			WithMessage("Waiting for other controllers to take over"))
+	return ctrl.Result{}, apply()
 }
 
 func (r *OnboardingController) deleteTestServers(ctx context.Context, host string) error {
@@ -417,10 +395,10 @@ func (r *OnboardingController) deleteTestServers(ctx context.Context, host strin
 	return errors.Join(errs...)
 }
 
-func (r *OnboardingController) ensureNovaProperties(ctx context.Context, hv *kvmv1.Hypervisor) error {
+func (r *OnboardingController) lookupNovaProperties(ctx context.Context, hv *kvmv1.Hypervisor) (hypervisorID, serviceID string, err error) {
 	hypervisorAddress := hv.Labels[corev1.LabelHostname]
 	if hypervisorAddress == "" {
-		return errRequeue
+		return "", "", errRequeue
 	}
 
 	shortHypervisorAddress := strings.SplitN(hypervisorAddress, ".", 2)[0]
@@ -429,41 +407,27 @@ func (r *OnboardingController) ensureNovaProperties(ctx context.Context, hv *kvm
 	hypervisorPages, err := hypervisors.List(r.computeClient, hypervisorQuery).AllPages(ctx)
 	if err != nil {
 		if gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
-			return errRequeue
+			return "", "", errRequeue
 		}
-		return err
+		return "", "", err
 	}
 
 	hs, err := hypervisors.ExtractHypervisors(hypervisorPages)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	if len(hs) < 1 {
-		return errRequeue
+		return "", "", errRequeue
 	}
 
-	var found = false
-	var myHypervisor hypervisors.Hypervisor
 	for _, h := range hs {
-		short := strings.SplitN(h.HypervisorHostname, ".", 2)[0]
-		if short == shortHypervisorAddress {
-			myHypervisor = h
-			found = true
-			break
+		if strings.SplitN(h.HypervisorHostname, ".", 2)[0] == shortHypervisorAddress {
+			return h.ID, h.Service.ID, nil
 		}
 	}
 
-	if !found {
-		return fmt.Errorf("could not find exact match for %v", shortHypervisorAddress)
-	}
-
-	hypervisorID := myHypervisor.ID
-	serviceID := myHypervisor.Service.ID
-	return utils.PatchHypervisorStatusWithRetry(ctx, r.Client, hv.Name, OnboardingControllerName, func(h *kvmv1.Hypervisor) {
-		h.Status.HypervisorID = hypervisorID
-		h.Status.ServiceID = serviceID
-	})
+	return "", "", fmt.Errorf("could not find exact match for %v", shortHypervisorAddress)
 }
 
 func (r *OnboardingController) createOrGetTestServer(ctx context.Context, zone, computeHost string, nodeUid types.UID) (*servers.Server, error) {
@@ -484,9 +448,9 @@ func (r *OnboardingController) createOrGetTestServer(ctx context.Context, zone, 
 	}
 
 	log := logger.FromContext(ctx)
+	var foundServer *servers.Server
 	// Cleanup all other server with the same test prefix, except for the exact match
 	// as the cleanup after onboarding may leak resources
-	var foundServer *servers.Server
 	for _, server := range serverList {
 		// The query is a substring search, we are looking for a prefix
 		if !strings.HasPrefix(server.Name, serverPrefix) {


### PR DESCRIPTION
Replace `PatchHypervisorStatusWithRetry` with `Status().Apply()`. The Nova ID lookup is inlined into `Reconcile` and combined with the initial condition in a single apply, avoiding two applies from the same field manager in one reconcile cycle which would cause SSA to prune the IDs. `HypervisorID` and `ServiceID` are included in every subsequent apply to retain ownership.

The status config is built once at the top of `Reconcile` and threaded through to all sub-functions (`abortOnboarding`, `initialOnboarding`, `smokeTest`, `completeOnboarding`) which mutate it directly. An apply closure is also passed so each function calls `apply()` when it has determined the desired condition, rather than building and applying the config itself. The flow becomes fully declarative: compute desired state, then apply once.

Seed only the condition owned by this controller (`ConditionTypeOnboarding`) so SSA does not claim ownership over conditions written by other controllers.

Depends on #335 (`ssa-conditions-helpers`).